### PR TITLE
Add HTTP/2 Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 axum = "0.7.9"
 bytes = "1.9.0"
 http-body-util = "0.1.2"
-hyper = { version = "1.5.2", features = ["client", "http1"] }
-hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1"] }
+hyper = { version = "1.5.2", features = ["client", "http1", "http2"] }
+hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1", "http2"] }
 tokio = { version = "1.42.0", features = ["full"] }
 tower = "0.5.2"
 tracing = "0.1.41"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -7,8 +7,8 @@ use tracing_subscriber::FmtSubscriber;
 #[tokio::main]
 async fn main() {
     // Initialize tracing
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::TRACE)
+    let _subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
         .with_target(false)
         .with_thread_ids(true)
         .with_file(true)


### PR DESCRIPTION
This PR adds support for HTTP/2 in the reverse proxy implementation, along with tests and linting fixes.