### PR TITLE
Add test for query parameter handling

### DIFF
--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -1,11 +1,4 @@
-use axum::{
-    body::Body,
-    extract::State,
-    http::Request,
-    response::Json,
-    routing::get,
-    Router,
-};
+use axum::{body::Body, extract::State, http::Request, response::Json, routing::get, Router};
 use axum_reverse_proxy::ReverseProxy;
 use serde_json::{json, Value};
 use tokio::net::TcpListener;


### PR DESCRIPTION
This PR adds a test case to verify that query parameters are correctly forwarded to the upstream server. The test covers: - Simple query parameters - Multiple query parameters - Empty query parameters - Special characters in query parameters. The test ensures that the query string is preserved exactly as it is received, including URL encoding.