### PR TITLE
chore: track Cargo.lock for reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.vscode/
+.cursorrules

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "axum-reverse-proxy"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "axum",
  "bytes",


### PR DESCRIPTION
This PR adds Cargo.lock to version control to ensure reproducible builds, particularly for our benchmarks. Rationale: - While libraries typically don't track Cargo.lock, we have benchmarks that should be reproducible - Having Cargo.lock in version control ensures consistent dependency versions across all environments - This helps with reproducible CI runs and benchmark comparisons - Follows Cargo's recommendation for packages with binaries (our benchmarks)