### PR TITLE
feat: add WebSocket support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ name = "axum-reverse-proxy"
 version = "0.3.0"
 dependencies = [
  "axum",
+ "base64 0.21.7",
  "bytes",
  "criterion",
  "futures-util",
@@ -164,12 +165,14 @@ dependencies = [
  "hyper-util",
  "reqwest",
  "serde_json",
+ "sha1",
  "tokio",
  "tokio-tungstenite 0.21.0",
  "tower 0.4.13",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.2.0",
@@ -118,8 +119,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -162,6 +165,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
+ "tokio-tungstenite 0.21.0",
  "tower 0.4.13",
  "tower-http",
  "tracing",
@@ -206,6 +210,15 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "brotli"
@@ -338,6 +351,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +436,32 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -575,6 +623,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1628,6 +1686,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +1820,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +1906,30 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -1977,6 +2090,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.2.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.2.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2154,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -2031,6 +2193,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,15 @@ tracing = "0.1.40"
 serde_json = "1.0.114"
 futures-util = "0.3.30"
 http = "1.0.0"
+tokio-tungstenite = "0.21.0"
+url = "2.5.0"
+base64 = "0.21.7"
+sha1 = "0.10.6"
 
 [dev-dependencies]
 reqwest = { version = "0.11.24", features = ["json"] }
 tracing-subscriber = "0.3.18"
 criterion = { version = "0.5.1", features = ["async", "async_tokio", "html_reports"] }
-tokio-tungstenite = "0.21.0"
 
 [[bench]]
 name = "proxy_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,7 @@ criterion = { version = "0.5.1", features = ["async", "async_tokio", "html_repor
 [[bench]]
 name = "proxy_bench"
 harness = false
+
+[[bench]]
+name = "websocket_bench"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server", "network-programming"]
 authors = ["Tom Lubenow"]
 
 [dependencies]
-axum = "0.7.9"
+axum = { version = "0.7.9", features = ["ws"] }
 hyper = { version = "1.5.2", features = ["full"] }
 hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
 tokio = { version = "1.42.0", features = ["full"] }
@@ -29,6 +29,7 @@ http = "1.0.0"
 reqwest = { version = "0.11.24", features = ["json"] }
 tracing-subscriber = "0.3.18"
 criterion = { version = "0.5.1", features = ["async", "async_tokio", "html_reports"] }
+tokio-tungstenite = "0.21.0"
 
 [[bench]]
 name = "proxy_bench"

--- a/benches/websocket_bench.rs
+++ b/benches/websocket_bench.rs
@@ -68,7 +68,11 @@ async fn setup_test_server() -> (SocketAddr, SocketAddr) {
     (upstream_addr, proxy_addr)
 }
 
-async fn bench_websocket_echo(proxy_addr: SocketAddr, message_size: usize, iterations: usize) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn bench_websocket_echo(
+    proxy_addr: SocketAddr,
+    message_size: usize,
+    iterations: usize,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Create a WebSocket client connection through the proxy
     let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());
     let (mut ws_stream, _) = tokio_tungstenite::connect_async(&url).await?;
@@ -106,7 +110,8 @@ fn websocket_benchmark(c: &mut Criterion) {
     for size in message_sizes {
         let bench_name = format!("websocket_echo_{}_bytes", size);
         c.bench_function(&bench_name, |b| {
-            b.to_async(&rt).iter(|| bench_websocket_echo(proxy_addr, size, 100));
+            b.to_async(&rt)
+                .iter(|| bench_websocket_echo(proxy_addr, size, 100));
         });
     }
 
@@ -131,4 +136,4 @@ fn websocket_benchmark(c: &mut Criterion) {
 }
 
 criterion_group!(benches, websocket_benchmark);
-criterion_main!(benches); 
+criterion_main!(benches);

--- a/benches/websocket_bench.rs
+++ b/benches/websocket_bench.rs
@@ -1,0 +1,134 @@
+use axum::{
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use axum_reverse_proxy::ReverseProxy;
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures_util::{SinkExt, StreamExt};
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite;
+use tracing::error;
+
+async fn websocket_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(mut socket: WebSocket) {
+    while let Some(msg) = socket.recv().await {
+        if let Ok(msg) = msg {
+            match msg {
+                Message::Text(text) => {
+                    if socket.send(Message::Text(text)).await.is_err() {
+                        break;
+                    }
+                }
+                Message::Binary(data) => {
+                    if socket.send(Message::Binary(data)).await.is_err() {
+                        break;
+                    }
+                }
+                Message::Close(_) => {
+                    let _ = socket.send(Message::Close(None)).await;
+                    break;
+                }
+                _ => {}
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+async fn setup_test_server() -> (SocketAddr, SocketAddr) {
+    // Create a WebSocket echo server
+    let app = Router::new().route("/ws", get(websocket_handler));
+    let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream_addr = upstream_listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(upstream_listener, app).await.unwrap();
+    });
+
+    // Create the proxy server
+    let proxy = ReverseProxy::new("/", &format!("http://{}", upstream_addr));
+    let proxy_app: Router = proxy.into();
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(proxy_listener, proxy_app).await.unwrap();
+    });
+
+    // Give the servers a moment to start
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    (upstream_addr, proxy_addr)
+}
+
+async fn bench_websocket_echo(proxy_addr: SocketAddr, message_size: usize, iterations: usize) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Create a WebSocket client connection through the proxy
+    let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&url).await?;
+
+    // Create a test message of the specified size
+    let test_message = "x".repeat(message_size);
+
+    for _ in 0..iterations {
+        // Send the test message
+        ws_stream
+            .send(tungstenite::Message::Text(test_message.clone()))
+            .await?;
+
+        // Receive the echo response
+        match ws_stream.next().await {
+            Some(Ok(_)) => (),
+            Some(Err(e)) => return Err(Box::new(e)),
+            None => return Err("Connection closed unexpectedly".into()),
+        }
+    }
+
+    // Close the connection
+    ws_stream.close(None).await?;
+    Ok(())
+}
+
+fn websocket_benchmark(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    // Set up the test server
+    let (_upstream_addr, proxy_addr) = rt.block_on(setup_test_server());
+
+    // Benchmark different message sizes
+    let message_sizes = [10, 100, 1000, 10000];
+    for size in message_sizes {
+        let bench_name = format!("websocket_echo_{}_bytes", size);
+        c.bench_function(&bench_name, |b| {
+            b.to_async(&rt).iter(|| bench_websocket_echo(proxy_addr, size, 100));
+        });
+    }
+
+    // Benchmark concurrent connections with smaller iteration counts
+    let concurrent_counts = [1, 5, 10, 20];
+    for count in concurrent_counts {
+        let bench_name = format!("websocket_concurrent_{}_connections", count);
+        c.bench_function(&bench_name, |b| {
+            b.to_async(&rt).iter(|| async {
+                let mut handles = Vec::new();
+                for _ in 0..count {
+                    handles.push(tokio::spawn(bench_websocket_echo(proxy_addr, 100, 5)));
+                }
+                for handle in handles {
+                    if let Err(e) = handle.await.unwrap() {
+                        error!("Benchmark error: {}", e);
+                    }
+                }
+            });
+        });
+    }
+}
+
+criterion_group!(benches, websocket_benchmark);
+criterion_main!(benches); 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 
 use axum::{body::Body, extract::State, http::Request, response::Response, Router};
 use bytes as bytes_crate;
-use futures_util::{SinkExt, StreamExt};
+use futures_util::SinkExt;
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use hyper::StatusCode;
 use hyper_util::{
@@ -56,18 +56,12 @@ use tokio_tungstenite::{
     connect_async,
     tungstenite::{
         handshake::client::Request as WsRequest,
-        protocol::frame::coding::CloseCode,
-        Message,
     },
-    WebSocketStream,
 };
 use tracing::{error, trace};
 use http::{HeaderMap, HeaderValue, Version};
 use url::Url;
-use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Error;
-
-type WebSocket = WebSocketStream<TokioIo<hyper::upgrade::Upgraded>>;
 
 /// Configuration options for the reverse proxy
 #[derive(Clone, Debug, Default)]

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -9,7 +9,7 @@ use futures_util::{SinkExt, StreamExt};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite;
-use tracing::{info, trace};
+use tracing::info;
 use tracing_subscriber::fmt::format::FmtSpan;
 
 async fn websocket_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
@@ -77,7 +77,7 @@ async fn setup_test_server() -> (SocketAddr, SocketAddr) {
 
 #[tokio::test]
 async fn test_websocket_upgrade() {
-    let (upstream_addr, proxy_addr) = setup_test_server().await;
+    let (_upstream_addr, proxy_addr) = setup_test_server().await;
 
     // Attempt WebSocket upgrade through the proxy
     let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());
@@ -90,7 +90,7 @@ async fn test_websocket_upgrade() {
 
 #[tokio::test]
 async fn test_websocket_echo() {
-    let (upstream_addr, proxy_addr) = setup_test_server().await;
+    let (_upstream_addr, proxy_addr) = setup_test_server().await;
 
     // Create a WebSocket client connection through the proxy
     let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());
@@ -142,7 +142,7 @@ async fn test_websocket_close() {
 
 #[tokio::test]
 async fn test_websocket_binary() {
-    let (upstream_addr, proxy_addr) = setup_test_server().await;
+    let (_upstream_addr, proxy_addr) = setup_test_server().await;
 
     // Create a WebSocket client connection through the proxy
     let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -62,7 +62,7 @@ async fn setup_test_server() -> (SocketAddr, SocketAddr) {
 
 #[tokio::test]
 async fn test_websocket_upgrade() {
-    let (upstream_addr, proxy_addr) = setup_test_server().await;
+    let (_upstream_addr, proxy_addr) = setup_test_server().await;
 
     // Attempt WebSocket upgrade through the proxy
     let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());
@@ -75,7 +75,7 @@ async fn test_websocket_upgrade() {
 
 #[tokio::test]
 async fn test_websocket_echo() {
-    let (upstream_addr, proxy_addr) = setup_test_server().await;
+    let (_upstream_addr, proxy_addr) = setup_test_server().await;
 
     // Create a WebSocket client connection through the proxy
     let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());
@@ -100,7 +100,7 @@ async fn test_websocket_echo() {
 
 #[tokio::test]
 async fn test_websocket_close() {
-    let (upstream_addr, proxy_addr) = setup_test_server().await;
+    let (_upstream_addr, proxy_addr) = setup_test_server().await;
 
     // Create a WebSocket client connection through the proxy
     let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());
@@ -117,7 +117,7 @@ async fn test_websocket_close() {
 
 #[tokio::test]
 async fn test_websocket_binary() {
-    let (upstream_addr, proxy_addr) = setup_test_server().await;
+    let (_upstream_addr, proxy_addr) = setup_test_server().await;
 
     // Create a WebSocket client connection through the proxy
     let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -100,7 +100,8 @@ async fn test_websocket_echo() {
 
     // Send a test message
     let test_message = "Hello, WebSocket!";
-    ws_stream.send(tungstenite::Message::Text(test_message.into()))
+    ws_stream
+        .send(tungstenite::Message::Text(test_message.into()))
         .await
         .expect("Failed to send message");
 
@@ -125,7 +126,10 @@ async fn test_websocket_close() {
         .expect("Failed to connect");
 
     // Close the connection
-    ws_stream.close(None).await.expect("Failed to close connection");
+    ws_stream
+        .close(None)
+        .await
+        .expect("Failed to close connection");
 
     // Wait for the close frame response
     while let Some(msg) = ws_stream.next().await {
@@ -152,7 +156,8 @@ async fn test_websocket_binary() {
 
     // Send a binary message
     let test_data = vec![1, 2, 3, 4, 5];
-    ws_stream.send(tungstenite::Message::Binary(test_data.clone()))
+    ws_stream
+        .send(tungstenite::Message::Binary(test_data.clone()))
         .await
         .expect("Failed to send binary message");
 
@@ -163,4 +168,4 @@ async fn test_websocket_binary() {
     } else {
         panic!("Did not receive response");
     }
-} 
+}

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -1,0 +1,156 @@
+use axum::{
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use axum_reverse_proxy::ReverseProxy;
+use futures_util::{SinkExt, StreamExt};
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite;
+use tracing_subscriber::fmt::format::FmtSpan;
+
+async fn websocket_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(mut socket: WebSocket) {
+    // Echo server - just send back what we receive
+    while let Some(msg) = socket.recv().await {
+        if let Ok(msg) = msg {
+            if let Message::Text(text) = msg {
+                if socket.send(Message::Text(text)).await.is_err() {
+                    break;
+                }
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+async fn setup_test_server() -> SocketAddr {
+    // Set up logging for tests
+    tracing_subscriber::fmt()
+        .with_span_events(FmtSpan::CLOSE)
+        .with_test_writer()
+        .try_init()
+        .ok();
+
+    // Create a WebSocket echo server
+    let app = Router::new().route("/ws", get(websocket_handler));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    addr
+}
+
+#[tokio::test]
+async fn test_websocket_upgrade() {
+    let upstream_addr = setup_test_server().await;
+    let upstream_url = format!("http://{}", upstream_addr);
+
+    // Create a reverse proxy pointing to our test server
+    let proxy = ReverseProxy::new("/ws", &upstream_url);
+    let app: Router = Router::new().merge(proxy);
+
+    // Create a client connection through the proxy
+    let client = reqwest::Client::builder()
+        .build()
+        .unwrap();
+
+    // Attempt WebSocket upgrade
+    let url = format!("ws://127.0.0.1:{}/ws", upstream_addr.port());
+    let _ws_client = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("Failed to connect");
+
+    // If we get here, the upgrade was successful
+}
+
+#[tokio::test]
+async fn test_websocket_echo() {
+    let upstream_addr = setup_test_server().await;
+    let upstream_url = format!("http://{}", upstream_addr);
+
+    // Create a reverse proxy pointing to our test server
+    let proxy = ReverseProxy::new("/ws", &upstream_url);
+    let app: Router = Router::new().merge(proxy);
+
+    // Create a WebSocket client connection
+    let url = format!("ws://127.0.0.1:{}/ws", upstream_addr.port());
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("Failed to connect");
+
+    // Send a test message
+    let test_message = "Hello, WebSocket!";
+    ws_stream.send(tungstenite::Message::Text(test_message.into()))
+        .await
+        .expect("Failed to send message");
+
+    // Receive the echo response
+    if let Some(msg) = ws_stream.next().await {
+        let msg = msg.expect("Failed to get message");
+        assert_eq!(msg, tungstenite::Message::Text(test_message.into()));
+    } else {
+        panic!("Did not receive response");
+    }
+}
+
+#[tokio::test]
+async fn test_websocket_close() {
+    let upstream_addr = setup_test_server().await;
+    let upstream_url = format!("http://{}", upstream_addr);
+
+    // Create a reverse proxy pointing to our test server
+    let proxy = ReverseProxy::new("/ws", &upstream_url);
+    let app: Router = Router::new().merge(proxy);
+
+    // Create a WebSocket client connection
+    let url = format!("ws://127.0.0.1:{}/ws", upstream_addr.port());
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("Failed to connect");
+
+    // Close the connection
+    ws_stream.close(None).await.expect("Failed to close connection");
+
+    // Verify we don't receive any more messages
+    assert!(ws_stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_websocket_binary() {
+    let upstream_addr = setup_test_server().await;
+    let upstream_url = format!("http://{}", upstream_addr);
+
+    // Create a reverse proxy pointing to our test server
+    let proxy = ReverseProxy::new("/ws", &upstream_url);
+    let app: Router = Router::new().merge(proxy);
+
+    // Create a WebSocket client connection
+    let url = format!("ws://127.0.0.1:{}/ws", upstream_addr.port());
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("Failed to connect");
+
+    // Send a binary message
+    let test_data = vec![1, 2, 3, 4, 5];
+    ws_stream.send(tungstenite::Message::Binary(test_data.clone()))
+        .await
+        .expect("Failed to send binary message");
+
+    // Receive the echo response
+    if let Some(msg) = ws_stream.next().await {
+        let msg = msg.expect("Failed to get message");
+        assert_eq!(msg, tungstenite::Message::Binary(test_data));
+    } else {
+        panic!("Did not receive response");
+    }
+} 


### PR DESCRIPTION
This PR adds WebSocket support to the reverse proxy, allowing it to proxy WebSocket connections between clients and upstream servers.\n\nFixes #1\n\nKey changes:\n- Add WebSocket upgrade detection and handling\n- Implement bidirectional frame forwarding\n- Handle WebSocket close frames properly\n- Add comprehensive WebSocket tests\n  - Connection upgrade\n  - Text message echo\n  - Binary message echo\n  - Connection close handling