### PR TITLE
docs: Add Tower middleware documentation and examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
- "tokio",
  "walkdir",
 ]
 
@@ -1143,6 +1142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,8 +1494,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1498,8 +1515,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2078,10 +2101,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,26 +13,27 @@ authors = ["Tom Lubenow"]
 
 [dependencies]
 axum = { version = "0.7.9", features = ["ws"] }
-hyper = { version = "1.5.2", features = ["full"] }
-hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
-tokio = { version = "1.42.0", features = ["full"] }
-tower = { version = "0.4.13", features = ["full"] }
-tower-http = { version = "0.6.2", features = ["full"] }
-http-body-util = "0.1.2"
+base64 = "0.21.7"
 bytes = "1.5.0"
-tracing = "0.1.40"
-serde_json = "1.0.114"
 futures-util = "0.3.30"
 http = "1.0.0"
-tokio-tungstenite = "0.21.0"
-url = "2.5.0"
-base64 = "0.21.7"
+http-body-util = "0.1.2"
+hyper = { version = "1.5.2", features = ["full"] }
+hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
 sha1 = "0.10.6"
+tokio = { version = "1.42.0", features = ["full"] }
+tokio-tungstenite = "0.21.0"
+tower = { version = "0.4.13", features = ["full"] }
+tracing = "0.1.40"
+url = "2.5.0"
 
 [dev-dependencies]
+criterion = { version = "0.5.1", features = ["async", "futures"] }
 reqwest = { version = "0.11.24", features = ["json"] }
-tracing-subscriber = "0.3.18"
-criterion = { version = "0.5.1", features = ["async", "async_tokio", "html_reports"] }
+serde_json = "1.0.114"
+tokio = { version = "1.42.0", features = ["full", "test-util"] }
+tower-http = { version = "0.6.2", features = ["full"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [[bench]]
 name = "proxy_bench"
@@ -41,3 +42,15 @@ harness = false
 [[bench]]
 name = "websocket_bench"
 harness = false
+
+[[example]]
+name = "basic"
+path = "examples/basic.rs"
+
+[[example]]
+name = "nested"
+path = "examples/nested.rs"
+
+[[example]]
+name = "tower_middleware"
+path = "examples/tower_middleware.rs"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/axum-reverse-proxy.svg)](https://crates.io/crates/axum-reverse-proxy)
 [![Documentation](https://docs.rs/axum-reverse-proxy/badge.svg)](https://docs.rs/axum-reverse-proxy)
 
-A flexible and efficient reverse proxy implementation for [Axum](https://github.com/tokio-rs/axum) web applications. This library provides a simple way to forward HTTP requests from your Axum application to upstream servers.
+A flexible and efficient reverse proxy implementation for [Axum](https://github.com/tokio-rs/axum) web applications. This library provides a simple way to forward HTTP requests from your Axum application to upstream servers. It is intended to be a simple implementation sitting on top of axum and hyper.
 
 ## Features
 

--- a/benches/proxy_bench.rs
+++ b/benches/proxy_bench.rs
@@ -8,8 +8,8 @@ use axum_reverse_proxy::{ProxyOptions, ReverseProxy};
 use criterion::{criterion_group, criterion_main, Criterion};
 use hyper::StatusCode;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio::runtime::Runtime;
 use tokio::sync::Notify;
 
 async fn create_test_server() -> String {
@@ -34,8 +34,7 @@ async fn create_test_server() -> String {
 }
 
 fn bench_http1_get(c: &mut Criterion) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
+    let rt = Runtime::new().unwrap();
     let test_addr = rt.block_on(create_test_server());
 
     // Streaming proxy
@@ -60,14 +59,21 @@ fn bench_http1_get(c: &mut Criterion) {
 
     let client = reqwest::Client::new();
 
-    c.bench_function("http1_get_streaming", |b| {
-        b.to_async(&rt).iter(|| async {
-            let response = client
-                .get(format!("http://{}/test", proxy_listener))
-                .send()
-                .await
-                .unwrap();
-            assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    let mut group = c.benchmark_group("http1_get");
+    group.bench_function("streaming", |b| {
+        b.iter_custom(|iters| {
+            rt.block_on(async {
+                let start = std::time::Instant::now();
+                for _ in 0..iters {
+                    let response = client
+                        .get(format!("http://{}/test", proxy_listener))
+                        .send()
+                        .await
+                        .unwrap();
+                    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+                }
+                start.elapsed()
+            })
         });
     });
 
@@ -97,21 +103,27 @@ fn bench_http1_get(c: &mut Criterion) {
         addr
     });
 
-    c.bench_function("http1_get_buffered", |b| {
-        b.to_async(&rt).iter(|| async {
-            let response = client
-                .get(format!("http://{}/test", buffered_proxy_listener))
-                .send()
-                .await
-                .unwrap();
-            assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    group.bench_function("buffered", |b| {
+        b.iter_custom(|iters| {
+            rt.block_on(async {
+                let start = std::time::Instant::now();
+                for _ in 0..iters {
+                    let response = client
+                        .get(format!("http://{}/test", buffered_proxy_listener))
+                        .send()
+                        .await
+                        .unwrap();
+                    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+                }
+                start.elapsed()
+            })
         });
     });
+    group.finish();
 }
 
 fn bench_http2_get(c: &mut Criterion) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
+    let rt = Runtime::new().unwrap();
     let test_addr = rt.block_on(create_test_server());
     let proxy = ReverseProxy::new("/", &format!("http://{}", test_addr));
     let app: Router = proxy.into();
@@ -137,21 +149,28 @@ fn bench_http2_get(c: &mut Criterion) {
         .build()
         .unwrap();
 
-    c.bench_function("http2_get", |b| {
-        b.to_async(&rt).iter(|| async {
-            let response = client
-                .get(format!("http://{}/test", proxy_listener))
-                .send()
-                .await
-                .unwrap();
-            assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    let mut group = c.benchmark_group("http2");
+    group.bench_function("get", |b| {
+        b.iter_custom(|iters| {
+            rt.block_on(async {
+                let start = std::time::Instant::now();
+                for _ in 0..iters {
+                    let response = client
+                        .get(format!("http://{}/test", proxy_listener))
+                        .send()
+                        .await
+                        .unwrap();
+                    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+                }
+                start.elapsed()
+            })
         });
     });
+    group.finish();
 }
 
 fn bench_large_payload(c: &mut Criterion) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
+    let rt = Runtime::new().unwrap();
     let test_addr = rt.block_on(create_test_server());
 
     // Streaming proxy
@@ -177,15 +196,22 @@ fn bench_large_payload(c: &mut Criterion) {
     let client = reqwest::Client::new();
     let large_data = "x".repeat(1024 * 1024); // 1MB payload
 
-    c.bench_function("large_payload_streaming", |b| {
-        b.to_async(&rt).iter(|| async {
-            let response = client
-                .post(format!("http://{}/echo", proxy_listener))
-                .body(large_data.clone())
-                .send()
-                .await
-                .unwrap();
-            assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    let mut group = c.benchmark_group("large_payload");
+    group.bench_function("streaming", |b| {
+        b.iter_custom(|iters| {
+            rt.block_on(async {
+                let start = std::time::Instant::now();
+                for _ in 0..iters {
+                    let response = client
+                        .post(format!("http://{}/echo", proxy_listener))
+                        .body(large_data.clone())
+                        .send()
+                        .await
+                        .unwrap();
+                    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+                }
+                start.elapsed()
+            })
         });
     });
 
@@ -215,22 +241,28 @@ fn bench_large_payload(c: &mut Criterion) {
         addr
     });
 
-    c.bench_function("large_payload_buffered", |b| {
-        b.to_async(&rt).iter(|| async {
-            let response = client
-                .post(format!("http://{}/echo", buffered_proxy_listener))
-                .body(large_data.clone())
-                .send()
-                .await
-                .unwrap();
-            assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    group.bench_function("buffered", |b| {
+        b.iter_custom(|iters| {
+            rt.block_on(async {
+                let start = std::time::Instant::now();
+                for _ in 0..iters {
+                    let response = client
+                        .post(format!("http://{}/echo", buffered_proxy_listener))
+                        .body(large_data.clone())
+                        .send()
+                        .await
+                        .unwrap();
+                    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+                }
+                start.elapsed()
+            })
         });
     });
+    group.finish();
 }
 
 fn bench_concurrent_requests(c: &mut Criterion) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
+    let rt = Runtime::new().unwrap();
     let test_addr = rt.block_on(create_test_server());
     let proxy = ReverseProxy::new("/", &format!("http://{}", test_addr));
     let app: Router = proxy.into();
@@ -253,33 +285,41 @@ fn bench_concurrent_requests(c: &mut Criterion) {
 
     let client = reqwest::Client::new();
 
-    c.bench_function("concurrent_requests", |b| {
-        b.to_async(&rt).iter(|| async {
-            let mut handles = Vec::new();
-            for _ in 0..10 {
-                let client = client.clone();
-                let addr = proxy_listener;
-                handles.push(tokio::spawn(async move {
-                    let response = client
-                        .get(format!("http://{}/test", addr))
-                        .send()
-                        .await
-                        .unwrap();
-                    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
-                }));
-            }
-            for handle in handles {
-                handle.await.unwrap();
-            }
+    let mut group = c.benchmark_group("concurrent_requests");
+    group.bench_function("10_concurrent", |b| {
+        b.iter_custom(|iters| {
+            rt.block_on(async {
+                let start = std::time::Instant::now();
+                for _ in 0..iters {
+                    let mut handles = Vec::new();
+                    for _ in 0..10 {
+                        let client = client.clone();
+                        let addr = proxy_listener;
+                        handles.push(tokio::spawn(async move {
+                            let response = client
+                                .get(format!("http://{}/test", addr))
+                                .send()
+                                .await
+                                .unwrap();
+                            assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+                        }));
+                    }
+                    for handle in handles {
+                        handle.await.unwrap();
+                    }
+                }
+                start.elapsed()
+            })
         });
     });
+    group.finish();
 }
 
 criterion_group!(
-    name = benches;
-    config = Criterion::default()
-        .measurement_time(Duration::from_secs(10))
-        .sample_size(10);
-    targets = bench_http1_get, bench_http2_get, bench_large_payload, bench_concurrent_requests
+    benches,
+    bench_http1_get,
+    bench_http2_get,
+    bench_large_payload,
+    bench_concurrent_requests
 );
 criterion_main!(benches);

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "Running cargo fmt..."
+cargo fmt --all -- --check
+
+echo "Running cargo check..."
+cargo check
+
+echo "Running clippy..."
+cargo clippy -- -D warnings
+cargo clippy --bench proxy_bench -- -D warnings
+cargo clippy --bench websocket_bench -- -D warnings
+
+echo "Running tests..."
+cargo test 

--- a/examples/tower_middleware.rs
+++ b/examples/tower_middleware.rs
@@ -1,0 +1,87 @@
+use axum::{body::Body, extract::State, response::IntoResponse, routing::get, serve, Router};
+use axum_reverse_proxy::ReverseProxy;
+use http::Request;
+use serde_json::json;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tower::ServiceBuilder;
+use tower_http::{timeout::TimeoutLayer, validate_request::ValidateRequestHeaderLayer};
+use tracing::{info, Level};
+use tracing_subscriber::FmtSubscriber;
+
+// Our app state type
+#[derive(Clone)]
+struct AppState {
+    app_name: String,
+}
+
+#[tokio::main]
+async fn main() {
+    // Initialize tracing
+    FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .with_target(false)
+        .with_thread_ids(true)
+        .with_file(true)
+        .with_line_number(true)
+        .compact()
+        .init();
+
+    // Create our app state
+    let state = AppState {
+        app_name: "Tower Middleware Example".to_string(),
+    };
+
+    // Create a reverse proxy that forwards requests to httpbin.org
+    let proxy = ReverseProxy::new("/api", "https://httpbin.org");
+
+    // Create our main router with app state
+    let app = Router::new()
+        .route("/", get(root_handler))
+        .with_state(state.clone());
+
+    // Convert proxy to router
+    let proxy_router: Router = proxy.into();
+
+    // Add middleware stack
+    let app = app.merge(
+        proxy_router.layer(
+            ServiceBuilder::new()
+                // Add request timeout
+                .layer(TimeoutLayer::new(Duration::from_secs(10)))
+                // Require API key for /api routes
+                .layer(ValidateRequestHeaderLayer::bearer("secret-api-key"))
+                // Add custom header
+                .map_request(|mut req: Request<Body>| {
+                    req.headers_mut()
+                        .insert("X-Custom-Header", "custom-value".parse().unwrap());
+                    req
+                }),
+        ),
+    );
+
+    // Create a TCP listener
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    info!("Server running on http://localhost:3000");
+    info!("Try:");
+    info!("  - GET /         -> App info");
+    info!("  - GET /api/ip   -> Proxied to httpbin.org/ip (requires Bearer token)");
+    info!("  - GET /api/uuid -> Proxied to httpbin.org/uuid (requires Bearer token)");
+    info!("");
+    info!("Example curl commands:");
+    info!("  curl http://localhost:3000/");
+    info!("  curl -H 'Authorization: Bearer secret-api-key' http://localhost:3000/api/ip");
+
+    // Run the server
+    serve(listener, app).await.unwrap();
+}
+
+async fn root_handler(State(state): State<AppState>) -> impl IntoResponse {
+    axum::Json(json!({
+        "app": state.app_name,
+        "endpoints": {
+            "/": "This info",
+            "/api/*": "Proxied to httpbin.org (requires Bearer token)"
+        }
+    }))
+}

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -1,0 +1,161 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    response::Json,
+    routing::get,
+    Router,
+};
+use axum_reverse_proxy::ReverseProxy;
+use http::header::{HeaderName, HeaderValue};
+use serde_json::{json, Value};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tower::ServiceBuilder;
+use tower_http::{timeout::TimeoutLayer, validate_request::ValidateRequestHeaderLayer};
+
+#[tokio::test]
+async fn test_proxy_with_middleware() {
+    // Create a test server that echoes headers
+    let app = Router::new().route(
+        "/headers",
+        get(|req: Request<Body>| async move {
+            let headers = req
+                .headers()
+                .iter()
+                .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap().to_string()))
+                .collect::<Vec<_>>();
+            Json(json!({ "headers": headers }))
+        }),
+    );
+
+    let test_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let test_addr = test_listener.local_addr().unwrap();
+    let test_server = tokio::spawn(async move {
+        axum::serve(test_listener, app).await.unwrap();
+    });
+
+    // Create a reverse proxy
+    let proxy = ReverseProxy::new("/", &format!("http://{}", test_addr));
+    let proxy_router: Router = proxy.into();
+
+    // Add middleware stack
+    let app = proxy_router.layer(
+        ServiceBuilder::new()
+            // Add request timeout
+            .layer(TimeoutLayer::new(Duration::from_secs(10)))
+            // Require API key
+            .layer(ValidateRequestHeaderLayer::bearer("test-token"))
+            // Add custom header
+            .map_request(|mut req: Request<Body>| {
+                req.headers_mut().insert(
+                    HeaderName::from_static("x-custom-header"),
+                    HeaderValue::from_static("custom-value"),
+                );
+                req
+            }),
+    );
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let proxy_server = tokio::spawn(async move {
+        axum::serve(proxy_listener, app).await.unwrap();
+    });
+
+    // Create a client
+    let client = reqwest::Client::new();
+
+    // Test 1: Request without auth token should fail
+    let response = client
+        .get(format!("http://{}/headers", proxy_addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status().as_u16(),
+        StatusCode::UNAUTHORIZED.as_u16()
+    );
+
+    // Test 2: Request with auth token should succeed and include custom header
+    let response = client
+        .get(format!("http://{}/headers", proxy_addr))
+        .header("Authorization", "Bearer test-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+
+    let body: Value = response.json().await.unwrap();
+    let headers = body.get("headers").unwrap().as_array().unwrap();
+
+    // Verify custom header was added
+    let has_custom_header = headers.iter().any(|h| {
+        h.as_array()
+            .unwrap()
+            .get(0)
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .eq_ignore_ascii_case("x-custom-header")
+            && h.as_array()
+                .unwrap()
+                .get(1)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .eq_ignore_ascii_case("custom-value")
+    });
+    assert!(has_custom_header, "Custom header not found in response");
+
+    // Clean up
+    proxy_server.abort();
+    test_server.abort();
+}
+
+#[tokio::test]
+async fn test_proxy_timeout_middleware() {
+    // Create a test server with artificial delay
+    let app = Router::new().route(
+        "/slow",
+        get(|| async {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            "Done"
+        }),
+    );
+
+    let test_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let test_addr = test_listener.local_addr().unwrap();
+    let test_server = tokio::spawn(async move {
+        axum::serve(test_listener, app).await.unwrap();
+    });
+
+    // Create a reverse proxy with a short timeout
+    let proxy = ReverseProxy::new("/", &format!("http://{}", test_addr));
+    let proxy_router: Router = proxy.into();
+
+    // Add timeout middleware
+    let app = proxy_router.layer(TimeoutLayer::new(Duration::from_millis(100)));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let proxy_server = tokio::spawn(async move {
+        axum::serve(proxy_listener, app).await.unwrap();
+    });
+
+    // Create a client
+    let client = reqwest::Client::new();
+
+    // Test: Request should timeout
+    let response = client
+        .get(format!("http://{}/slow", proxy_addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status().as_u16(),
+        StatusCode::REQUEST_TIMEOUT.as_u16()
+    );
+
+    // Clean up
+    proxy_server.abort();
+    test_server.abort();
+}


### PR DESCRIPTION
- Add documentation for using Tower middleware with the proxy
- Add tower_middleware.rs example showing common middleware patterns
- Add tests to verify middleware functionality
- Document how to transform requests/responses using Tower instead of custom implementation
- Closes #16