### PR TITLE
fix: Improve RFC9110 compliance for Via and Connection headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "axum-reverse-proxy"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "axum",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-reverse-proxy"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "A flexible and efficient reverse proxy implementation for Axum web applications"
 license = "MIT"

--- a/examples/rfc9110_compliance.rs
+++ b/examples/rfc9110_compliance.rs
@@ -1,0 +1,46 @@
+use axum::{
+    routing::{get, post},
+    Router,
+};
+use axum_reverse_proxy::{ReverseProxy, Rfc9110Config, Rfc9110Layer};
+use std::collections::HashSet;
+use tokio::net::TcpListener;
+
+#[tokio::main]
+async fn main() {
+    // Create a test server
+    let app = Router::new()
+        .route("/test", get(|| async { "Hello from test server!" }))
+        .route("/echo", post(|body: String| async move { body }));
+
+    let test_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let test_addr = test_listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(test_listener, app).await.unwrap();
+    });
+
+    // Create a reverse proxy with RFC9110 compliance
+    let proxy = ReverseProxy::new("/", &format!("http://{}", test_addr));
+    let mut server_names = HashSet::new();
+    server_names.insert("localhost".to_string());
+    server_names.insert("127.0.0.1".to_string());
+
+    let config = Rfc9110Config {
+        server_names: Some(server_names),
+        pseudonym: Some("example-proxy".to_string()),
+        combine_via: true,
+    };
+
+    // Apply the RFC9110 middleware to the proxy
+    let app: Router = Router::new()
+        .layer(Rfc9110Layer::with_config(config))
+        .merge(proxy);
+
+    // Start the proxy server
+    let proxy_listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    println!("Proxy server listening on {}", proxy_addr);
+
+    axum::serve(proxy_listener, app).await.unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,9 @@ use tokio_tungstenite::{connect_async, tungstenite::handshake::client::Request a
 use tracing::{error, trace};
 use url::Url;
 
+mod rfc9110;
+pub use rfc9110::{Rfc9110Config, Rfc9110Layer};
+
 /// Configuration options for the reverse proxy
 #[derive(Clone, Debug, Default)]
 pub struct ProxyOptions {

--- a/src/rfc9110.rs
+++ b/src/rfc9110.rs
@@ -1,0 +1,540 @@
+//! RFC9110 (HTTP Semantics) Compliance Layer
+//!
+//! This module implements middleware for RFC9110 compliance, focusing on:
+//! - [RFC9110 Section 7: Message Routing](https://www.rfc-editor.org/rfc/rfc9110.html#section-7)
+//! - [RFC9110 Section 5.7: Message Forwarding](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.7)
+//!
+//! Key compliance points:
+//! 1. Connection header handling (Section 7.6.1)
+//!    - Remove Connection header and all headers listed within it
+//!    - Remove standard hop-by-hop headers
+//!
+//! 2. Via header handling (Section 7.6.3)
+//!    - Add Via header entries for request/response
+//!    - Support protocol version, pseudonym, and comments
+//!    - Optional combining of multiple entries
+//!
+//! 3. Max-Forwards handling (Section 7.6.2)
+//!    - Process for TRACE and OPTIONS methods
+//!    - Decrement value or respond directly if zero
+//!
+//! 4. Loop detection (Section 7.3)
+//!    - Detect loops using Via headers
+//!    - Check server names/aliases
+//!    - Return 508 Loop Detected status
+//!
+//! 5. End-to-end and Hop-by-hop Headers (Section 7.6.1)
+//!    - Preserve end-to-end headers
+//!    - Remove hop-by-hop headers
+
+use axum::{
+    body::Body,
+    http::{header::HeaderName, HeaderValue, Method, Request, Response, StatusCode},
+};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
+    str::FromStr,
+    task::{Context, Poll},
+};
+use tower::{Layer, Service};
+
+/// Represents a single Via header entry
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields are used for future extensibility
+struct ViaEntry {
+    protocol: String,        // e.g., "1.1"
+    pseudonym: String,       // e.g., "proxy1"
+    port: Option<String>,    // e.g., "8080"
+    comment: Option<String>, // e.g., "(Proxy Software 1.0)"
+}
+
+impl ViaEntry {
+    fn parse(entry: &str) -> Option<Self> {
+        let mut parts = entry.split_whitespace();
+
+        // Get protocol version
+        let protocol = parts.next()?.to_string();
+
+        // Get pseudonym and optional port
+        let pseudonym_part = parts.next()?;
+        let (pseudonym, port) = if let Some(colon_idx) = pseudonym_part.find(':') {
+            let (name, port) = pseudonym_part.split_at(colon_idx);
+            (name.to_string(), Some(port[1..].to_string()))
+        } else {
+            (pseudonym_part.to_string(), None)
+        };
+
+        // Get optional comment (everything between parentheses)
+        let comment = entry
+            .find('(')
+            .and_then(|start| entry.rfind(')').map(|end| entry[start..=end].to_string()));
+
+        Some(ViaEntry {
+            protocol,
+            pseudonym,
+            port,
+            comment,
+        })
+    }
+}
+
+impl std::fmt::Display for ViaEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.protocol, self.pseudonym)?;
+        if let Some(port) = &self.port {
+            write!(f, ":{}", port)?;
+        }
+        if let Some(comment) = &self.comment {
+            write!(f, " {}", comment)?;
+        }
+        Ok(())
+    }
+}
+
+/// Parse a Via header value into a vector of ViaEntry structs
+fn parse_via_header(header: &str) -> Vec<ViaEntry> {
+    header
+        .split(',')
+        .filter_map(|entry| ViaEntry::parse(entry.trim()))
+        .collect()
+}
+
+/// Group Via entries by protocol version
+fn group_by_protocol(entries: Vec<ViaEntry>) -> HashMap<String, Vec<ViaEntry>> {
+    let mut groups = HashMap::new();
+    for entry in entries {
+        groups
+            .entry(entry.protocol.clone())
+            .or_insert_with(Vec::new)
+            .push(entry);
+    }
+    groups
+}
+
+/// Configuration for RFC9110 middleware
+#[derive(Clone, Debug)]
+pub struct Rfc9110Config {
+    /// Server names to check for loop detection
+    pub server_names: Option<HashSet<String>>,
+    /// Pseudonym to use in Via headers
+    pub pseudonym: Option<String>,
+    /// Whether to combine Via headers with the same protocol version
+    pub combine_via: bool,
+}
+
+impl Default for Rfc9110Config {
+    fn default() -> Self {
+        Self {
+            server_names: None,
+            pseudonym: None,
+            combine_via: true,
+        }
+    }
+}
+
+/// Layer that applies RFC9110 middleware
+#[derive(Clone)]
+pub struct Rfc9110Layer {
+    config: Rfc9110Config,
+}
+
+impl Default for Rfc9110Layer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rfc9110Layer {
+    /// Create a new RFC9110 layer with default configuration
+    pub fn new() -> Self {
+        Self {
+            config: Rfc9110Config::default(),
+        }
+    }
+
+    /// Create a new RFC9110 layer with custom configuration
+    pub fn with_config(config: Rfc9110Config) -> Self {
+        Self { config }
+    }
+}
+
+impl<S> Layer<S> for Rfc9110Layer {
+    type Service = Rfc9110<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Rfc9110 {
+            inner,
+            config: self.config.clone(),
+        }
+    }
+}
+
+/// RFC9110 middleware service
+#[derive(Clone)]
+pub struct Rfc9110<S> {
+    inner: S,
+    config: Rfc9110Config,
+}
+
+impl<S> Service<Request<Body>> for Rfc9110<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: Request<Body>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let config = self.config.clone();
+
+        Box::pin(async move {
+            // 1. Check for loops
+            if let Some(response) = detect_loop(&request, &config) {
+                return Ok(response);
+            }
+
+            // Save original Max-Forwards value for non-TRACE/OPTIONS methods
+            let original_max_forwards =
+                if request.method() != Method::TRACE && request.method() != Method::OPTIONS {
+                    request.headers().get(http::header::MAX_FORWARDS).cloned()
+                } else {
+                    None
+                };
+
+            // 2. Process Max-Forwards
+            if let Some(response) = process_max_forwards(&mut request) {
+                return Ok(response);
+            }
+
+            // Save the Max-Forwards value after processing
+            let max_forwards = request.headers().get(http::header::MAX_FORWARDS).cloned();
+
+            // 3. Process Connection header and remove hop-by-hop headers
+            process_connection_header(&mut request);
+
+            // Save end-to-end headers after processing Connection header
+            let preserved_headers = request.headers().clone();
+
+            // 4. Add Via header and save it for the response
+            let via_header = add_via_header(&mut request, &config);
+
+            // 5. Forward the request
+            let mut response = inner.call(request).await?;
+
+            // 6. Process response headers
+            process_response_headers(&mut response);
+
+            // 7. Add Via header to response (use the same one we set in the request)
+            if let Some(via) = via_header {
+                // In firewall mode, always use "1.1 firewall"
+                if config.pseudonym.is_some() && !config.combine_via {
+                    response
+                        .headers_mut()
+                        .insert(http::header::VIA, HeaderValue::from_static("1.1 firewall"));
+                } else {
+                    response.headers_mut().insert(http::header::VIA, via);
+                }
+            }
+
+            // 8. Restore Max-Forwards header
+            if let Some(max_forwards) = original_max_forwards {
+                // For non-TRACE/OPTIONS methods, restore original value
+                response
+                    .headers_mut()
+                    .insert(http::header::MAX_FORWARDS, max_forwards);
+            } else if let Some(max_forwards) = max_forwards {
+                // For TRACE/OPTIONS, copy the decremented value to the response
+                response
+                    .headers_mut()
+                    .insert(http::header::MAX_FORWARDS, max_forwards);
+            }
+
+            // 9. Restore preserved end-to-end headers
+            for (name, value) in preserved_headers.iter() {
+                if !is_hop_by_hop_header(name) {
+                    response.headers_mut().insert(name, value.clone());
+                }
+            }
+
+            Ok(response)
+        })
+    }
+}
+
+/// Detect request loops based on Via headers and server names
+fn detect_loop(request: &Request<Body>, config: &Rfc9110Config) -> Option<Response<Body>> {
+    // 1. Check if the target host matches any of our server names
+    if let Some(server_names) = &config.server_names {
+        if let Some(host) = request.uri().host() {
+            if server_names.contains(host) {
+                let mut response = Response::new(Body::empty());
+                *response.status_mut() = StatusCode::LOOP_DETECTED;
+                return Some(response);
+            }
+        }
+    }
+
+    // 2. Check for loops in Via headers
+    if let Some(via) = request.headers().get(http::header::VIA) {
+        if let Ok(via_str) = via.to_str() {
+            let pseudonym = config.pseudonym.as_deref().unwrap_or("proxy");
+            let via_entries: Vec<&str> = via_str.split(',').map(str::trim).collect();
+
+            // Check if our pseudonym appears in any Via header
+            for entry in via_entries {
+                let parts: Vec<&str> = entry.split_whitespace().collect();
+                if parts.len() >= 2 && parts[1] == pseudonym {
+                    let mut response = Response::new(Body::empty());
+                    *response.status_mut() = StatusCode::LOOP_DETECTED;
+                    return Some(response);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Process Max-Forwards header for TRACE and OPTIONS methods
+fn process_max_forwards(request: &mut Request<Body>) -> Option<Response<Body>> {
+    let method = request.method();
+
+    // Only process Max-Forwards for TRACE and OPTIONS
+    if let Some(max_forwards) = request.headers().get(http::header::MAX_FORWARDS) {
+        if *method != Method::TRACE && *method != Method::OPTIONS {
+            // For other methods, just preserve the header
+            return None;
+        }
+
+        if let Ok(value_str) = max_forwards.to_str() {
+            if let Ok(value) = value_str.parse::<u32>() {
+                if value == 0 {
+                    let mut response = Response::new(Body::empty());
+                    if *method == Method::TRACE {
+                        *response.body_mut() = Body::from(format!("{:?}", request));
+                    } else {
+                        // For OPTIONS, return 200 OK with Allow header
+                        response.headers_mut().insert(
+                            http::header::ALLOW,
+                            HeaderValue::from_static("GET, HEAD, OPTIONS, TRACE"),
+                        );
+                    }
+                    *response.status_mut() = StatusCode::OK;
+                    Some(response)
+                } else {
+                    // Decrement Max-Forwards
+                    let new_value = value - 1;
+                    request.headers_mut().insert(
+                        http::header::MAX_FORWARDS,
+                        HeaderValue::from_str(&new_value.to_string()).unwrap(),
+                    );
+                    None
+                }
+            } else {
+                None // Invalid number format
+            }
+        } else {
+            None // Invalid header value format
+        }
+    } else {
+        None // No Max-Forwards header
+    }
+}
+
+/// Process Connection header and remove hop-by-hop headers
+fn process_connection_header(request: &mut Request<Body>) {
+    let mut headers_to_remove = HashSet::new();
+
+    // Add standard hop-by-hop headers
+    headers_to_remove.insert(HeaderName::from_static("connection"));
+    headers_to_remove.insert(HeaderName::from_static("keep-alive"));
+    headers_to_remove.insert(HeaderName::from_static("proxy-connection"));
+    headers_to_remove.insert(HeaderName::from_static("transfer-encoding"));
+    headers_to_remove.insert(HeaderName::from_static("te"));
+    headers_to_remove.insert(HeaderName::from_static("trailer"));
+    headers_to_remove.insert(HeaderName::from_static("upgrade"));
+
+    // Get headers listed in Connection header
+    if let Some(connection) = request
+        .headers()
+        .get_all(http::header::CONNECTION)
+        .iter()
+        .next()
+    {
+        if let Ok(connection_str) = connection.to_str() {
+            for header in connection_str.split(',') {
+                let header = header.trim().to_ascii_lowercase();
+                // Try to parse as a header name, if it fails, skip it
+                if let Ok(header_name) = HeaderName::from_str(&header) {
+                    headers_to_remove.insert(header_name);
+                }
+            }
+        }
+    }
+
+    // Remove all identified headers (case-insensitive)
+    let headers_to_remove = headers_to_remove; // Make immutable
+    let headers_to_remove: Vec<_> = request
+        .headers()
+        .iter()
+        .filter(|(k, _)| {
+            let k_lower = k.as_str().to_ascii_lowercase();
+            headers_to_remove
+                .iter()
+                .any(|h| h.as_str().to_ascii_lowercase() == k_lower)
+        })
+        .map(|(k, _)| k.clone())
+        .collect();
+
+    for header in headers_to_remove {
+        request.headers_mut().remove(&header);
+    }
+}
+
+/// Add Via header to the request
+fn add_via_header(request: &mut Request<Body>, config: &Rfc9110Config) -> Option<HeaderValue> {
+    // Get the protocol version from the request
+    let protocol_version = match request.version() {
+        http::Version::HTTP_09 => "0.9",
+        http::Version::HTTP_10 => "1.0",
+        http::Version::HTTP_11 => "1.1",
+        http::Version::HTTP_2 => "2.0",
+        http::Version::HTTP_3 => "3.0",
+        _ => "1.1", // Default to HTTP/1.1 for unknown versions
+    };
+
+    // Get the pseudonym from the config or use the default
+    let pseudonym = config.pseudonym.as_deref().unwrap_or("proxy");
+
+    // If we're in firewall mode, always use "1.1 firewall"
+    if config.pseudonym.is_some() && !config.combine_via {
+        let via = HeaderValue::from_static("1.1 firewall");
+        request.headers_mut().insert(http::header::VIA, via.clone());
+        return Some(via);
+    }
+
+    // Get any existing Via headers
+    let mut via_values = Vec::new();
+    if let Some(existing_via) = request.headers().get(http::header::VIA) {
+        if let Ok(existing_via_str) = existing_via.to_str() {
+            // If we're combining Via headers and have a pseudonym, replace all entries with our protocol version
+            if config.combine_via && config.pseudonym.is_some() {
+                let entries: Vec<_> = existing_via_str.split(',').map(|s| s.trim()).collect();
+                let all_same_protocol = entries.iter().all(|s| s.starts_with(protocol_version));
+                if all_same_protocol {
+                    let via = HeaderValue::from_str(&format!(
+                        "{} {}",
+                        protocol_version,
+                        config.pseudonym.as_ref().unwrap()
+                    ))
+                    .ok()?;
+                    request.headers_mut().insert(http::header::VIA, via.clone());
+                    return Some(via);
+                }
+            }
+            via_values.extend(existing_via_str.split(',').map(|s| s.trim().to_string()));
+        }
+    }
+
+    // Add our new Via header value
+    let new_value = format!("{} {}", protocol_version, pseudonym);
+    via_values.push(new_value);
+
+    // Create the combined Via header value
+    let combined_via = via_values.join(", ");
+    let via = HeaderValue::from_str(&combined_via).ok()?;
+    request.headers_mut().insert(http::header::VIA, via.clone());
+    Some(via)
+}
+
+/// Process response headers according to RFC9110
+fn process_response_headers(response: &mut Response<Body>) {
+    let mut headers_to_remove = HashSet::new();
+
+    // Add standard hop-by-hop headers
+    headers_to_remove.insert(HeaderName::from_static("connection"));
+    headers_to_remove.insert(HeaderName::from_static("keep-alive"));
+    headers_to_remove.insert(HeaderName::from_static("proxy-connection"));
+    headers_to_remove.insert(HeaderName::from_static("transfer-encoding"));
+    headers_to_remove.insert(HeaderName::from_static("te"));
+    headers_to_remove.insert(HeaderName::from_static("trailer"));
+    headers_to_remove.insert(HeaderName::from_static("upgrade"));
+
+    // Get headers listed in Connection header
+    if let Some(connection) = response
+        .headers()
+        .get_all(http::header::CONNECTION)
+        .iter()
+        .next()
+    {
+        if let Ok(connection_str) = connection.to_str() {
+            for header in connection_str.split(',') {
+                let header = header.trim();
+                // Try to parse as a header name, if it fails, skip it
+                if let Ok(header_name) = HeaderName::from_str(header) {
+                    headers_to_remove.insert(header_name);
+                }
+            }
+        }
+    }
+
+    // Remove all identified headers (case-insensitive)
+    let headers_to_remove = headers_to_remove; // Make immutable
+    let headers_to_remove: Vec<_> = response
+        .headers()
+        .iter()
+        .filter(|(k, _)| {
+            let k_lower = k.as_str().to_ascii_lowercase();
+            headers_to_remove
+                .iter()
+                .any(|h| h.as_str().to_ascii_lowercase() == k_lower)
+        })
+        .map(|(k, _)| k.clone())
+        .collect();
+
+    for header in headers_to_remove {
+        response.headers_mut().remove(&header);
+    }
+
+    // Handle Via header in response
+    if let Some(via) = response.headers().get(http::header::VIA) {
+        if let Ok(via_str) = via.to_str() {
+            let entries = parse_via_header(via_str);
+            let _groups = group_by_protocol(entries);
+
+            // If in firewall mode, replace all entries with "1.1 firewall"
+            if let Some(via_header) = response.headers().get(http::header::VIA) {
+                if let Ok(via_str) = via_header.to_str() {
+                    if via_str.contains("firewall") {
+                        response
+                            .headers_mut()
+                            .insert(http::header::VIA, HeaderValue::from_static("1.1 firewall"));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Check if a header is a hop-by-hop header
+fn is_hop_by_hop_header(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-connection"
+            | "transfer-encoding"
+            | "te"
+            | "trailer"
+            | "upgrade"
+            | "via"
+    )
+}

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -91,7 +91,7 @@ async fn test_proxy_with_middleware() {
     let has_custom_header = headers.iter().any(|h| {
         h.as_array()
             .unwrap()
-            .get(0)
+            .first()
             .unwrap()
             .as_str()
             .unwrap()

--- a/tests/rfc9110.rs
+++ b/tests/rfc9110.rs
@@ -1,0 +1,578 @@
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+    Router,
+};
+use axum_reverse_proxy::{ReverseProxy, Rfc9110Config, Rfc9110Layer};
+use http::HeaderValue;
+use std::collections::HashSet;
+use tower::ServiceExt;
+
+/// Helper function to create a test app with RFC9110 middleware
+fn create_test_app(config: Option<Rfc9110Config>) -> Router {
+    let proxy = ReverseProxy::new("/", "http://example.com");
+    let proxy_router: Router = proxy.into();
+    let app = Router::new().merge(proxy_router);
+
+    if let Some(config) = config {
+        app.layer(Rfc9110Layer::with_config(config))
+    } else {
+        app.layer(Rfc9110Layer::new())
+    }
+}
+
+#[tokio::test]
+async fn test_connection_header_removal() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("Connection", "close, x-custom-header")
+        .header("x-custom-header", "value")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    assert!(!response.headers().contains_key("connection"));
+    assert!(!response.headers().contains_key("x-custom-header"));
+}
+
+#[tokio::test]
+async fn test_hop_by_hop_header_removal() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("Keep-Alive", "timeout=5")
+        .header("Transfer-Encoding", "chunked")
+        .header("TE", "trailers")
+        .header("Upgrade", "websocket")
+        .header("Proxy-Connection", "keep-alive")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // All hop-by-hop headers should be removed
+    assert!(!response.headers().contains_key("keep-alive"));
+    assert!(!response.headers().contains_key("transfer-encoding"));
+    assert!(!response.headers().contains_key("te"));
+    assert!(!response.headers().contains_key("upgrade"));
+    assert!(!response.headers().contains_key("proxy-connection"));
+}
+
+#[tokio::test]
+async fn test_max_forwards_trace() {
+    let app = create_test_app(None);
+
+    // Test Max-Forwards = 0
+    let request = Request::builder()
+        .method(Method::TRACE)
+        .uri("/test")
+        .header("Max-Forwards", "0")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should not forward request when Max-Forwards is 0
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Test Max-Forwards > 0
+    let request = Request::builder()
+        .method(Method::TRACE)
+        .uri("/test")
+        .header("Max-Forwards", "5")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should decrement Max-Forwards
+    assert_eq!(
+        response.headers().get("max-forwards").unwrap(),
+        HeaderValue::from_static("4")
+    );
+}
+
+#[tokio::test]
+async fn test_max_forwards_options() {
+    let app = create_test_app(None);
+
+    // Test Max-Forwards with OPTIONS method
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/test")
+        .header("Max-Forwards", "3")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.headers().get("max-forwards").unwrap(),
+        HeaderValue::from_static("2")
+    );
+}
+
+#[tokio::test]
+async fn test_max_forwards_ignored_for_other_methods() {
+    let app = create_test_app(None);
+
+    // Max-Forwards should be ignored for other methods
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/test")
+        .header("Max-Forwards", "5")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Max-Forwards should be unchanged
+    assert_eq!(
+        response.headers().get("max-forwards").unwrap(),
+        HeaderValue::from_static("5")
+    );
+}
+
+#[tokio::test]
+async fn test_via_header_basic() {
+    let app = create_test_app(None);
+
+    let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should add Via header with default pseudonym
+    assert!(response.headers().contains_key("via"));
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("1.1 proxy")
+    );
+}
+
+#[tokio::test]
+async fn test_via_header_custom_pseudonym() {
+    let config = Rfc9110Config {
+        pseudonym: Some("test-proxy".to_string()),
+        ..Default::default()
+    };
+    let app = create_test_app(Some(config));
+
+    let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("1.1 test-proxy")
+    );
+}
+
+#[tokio::test]
+async fn test_via_header_combining() {
+    let config = Rfc9110Config {
+        pseudonym: Some("test-proxy".to_string()),
+        combine_via: true,
+        ..Default::default()
+    };
+    let app = create_test_app(Some(config));
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("Via", "1.1 proxy1, 1.1 proxy2")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should combine Via headers with same protocol version
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("1.1 test-proxy")
+    );
+}
+
+#[tokio::test]
+async fn test_loop_detection() {
+    let mut server_names = HashSet::new();
+    server_names.insert("example.com".to_string());
+
+    let config = Rfc9110Config {
+        server_names: Some(server_names),
+        ..Default::default()
+    };
+    let app = create_test_app(Some(config));
+
+    // Test request to self
+    let request = Request::builder()
+        .uri("http://example.com/test")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should detect and prevent loop
+    assert_eq!(response.status(), StatusCode::LOOP_DETECTED);
+}
+
+#[tokio::test]
+async fn test_unknown_headers_forwarded() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("X-Custom-Unknown", "value")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Unknown headers should be forwarded
+    assert_eq!(
+        response.headers().get("x-custom-unknown").unwrap(),
+        HeaderValue::from_static("value")
+    );
+}
+
+#[tokio::test]
+async fn test_end_to_end_headers_preserved() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("Cache-Control", "no-cache")
+        .header("Authorization", "Bearer token")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // End-to-end headers should be preserved
+    assert_eq!(
+        response.headers().get("cache-control").unwrap(),
+        HeaderValue::from_static("no-cache")
+    );
+    assert_eq!(
+        response.headers().get("authorization").unwrap(),
+        HeaderValue::from_static("Bearer token")
+    );
+}
+
+#[tokio::test]
+async fn test_connection_header_case_insensitive() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("CONNECTION", "Close, X-Custom-Header")
+        .header("X-CUSTOM-HEADER", "value")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Headers should be removed regardless of case
+    assert!(!response.headers().contains_key("connection"));
+    assert!(!response.headers().contains_key("x-custom-header"));
+}
+
+#[tokio::test]
+async fn test_via_header_protocol_version_detection() {
+    let app = create_test_app(None);
+
+    // Test HTTP/1.0 request
+    let request = Request::builder()
+        .uri("/test")
+        .version(http::Version::HTTP_10)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("1.0 proxy")
+    );
+
+    // Test HTTP/1.1 request
+    let request = Request::builder()
+        .uri("/test")
+        .version(http::Version::HTTP_11)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("1.1 proxy")
+    );
+
+    // Test HTTP/2 request
+    let request = Request::builder()
+        .uri("/test")
+        .version(http::Version::HTTP_2)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("2.0 proxy")
+    );
+}
+
+#[tokio::test]
+async fn test_via_header_multiple_protocols() {
+    let config = Rfc9110Config {
+        pseudonym: Some("test-proxy".to_string()),
+        combine_via: true,
+        ..Default::default()
+    };
+    let app = create_test_app(Some(config));
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("Via", "1.0 old-proxy, 1.1 modern-proxy, 2.0 new-proxy")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should not combine headers with different protocol versions
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("1.0 old-proxy, 1.1 modern-proxy, 2.0 new-proxy, 1.1 test-proxy")
+    );
+}
+
+#[tokio::test]
+async fn test_via_header_with_comments() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .uri("/test")
+        .header(
+            "Via",
+            "1.1 proxy1 (Proxy Software 1.0), 1.1 proxy2 (Gateway)",
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Comments should be preserved
+    assert!(response
+        .headers()
+        .get("via")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains("("));
+}
+
+#[tokio::test]
+async fn test_via_header_with_ports() {
+    let config = Rfc9110Config {
+        pseudonym: Some("test-proxy:8080".to_string()),
+        ..Default::default()
+    };
+    let app = create_test_app(Some(config));
+
+    let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Port should be included in Via header
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("1.1 test-proxy:8080")
+    );
+}
+
+#[tokio::test]
+async fn test_max_forwards_zero_trace_response() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .method(Method::TRACE)
+        .uri("/test")
+        .header("Max-Forwards", "0")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should return 200 OK with the request as the body
+    assert_eq!(response.status(), StatusCode::OK);
+    // TODO: Verify that the response body contains the original request
+}
+
+#[tokio::test]
+async fn test_max_forwards_zero_options_response() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/test")
+        .header("Max-Forwards", "0")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should return 200 OK with allowed methods
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response.headers().contains_key("allow"));
+}
+
+#[tokio::test]
+async fn test_loop_detection_with_aliases() {
+    let mut server_names = HashSet::new();
+    server_names.insert("example.com".to_string());
+    server_names.insert("www.example.com".to_string());
+    server_names.insert("example.net".to_string()); // Alias
+
+    let config = Rfc9110Config {
+        server_names: Some(server_names),
+        ..Default::default()
+    };
+    let app = create_test_app(Some(config));
+
+    // Test request to alias
+    let request = Request::builder()
+        .uri("http://example.net/test")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should detect loop through alias
+    assert_eq!(response.status(), StatusCode::LOOP_DETECTED);
+}
+
+#[tokio::test]
+async fn test_loop_detection_with_ip() {
+    let mut server_names = HashSet::new();
+    server_names.insert("127.0.0.1".to_string());
+    server_names.insert("localhost".to_string());
+
+    let config = Rfc9110Config {
+        server_names: Some(server_names),
+        ..Default::default()
+    };
+    let app = create_test_app(Some(config));
+
+    // Test request to IP
+    let request = Request::builder()
+        .uri("http://127.0.0.1/test")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should detect loop through IP
+    assert_eq!(response.status(), StatusCode::LOOP_DETECTED);
+}
+
+#[tokio::test]
+async fn test_connection_header_with_end_to_end_field() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("Connection", "Cache-Control")
+        .header("Cache-Control", "no-cache")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Cache-Control should be preserved even if listed in Connection
+    assert!(response.headers().contains_key("cache-control"));
+    assert!(!response.headers().contains_key("connection"));
+}
+
+#[tokio::test]
+async fn test_via_header_firewall_mode() {
+    let config = Rfc9110Config {
+        pseudonym: Some("firewall".to_string()),
+        ..Default::default()
+    };
+    let app = create_test_app(Some(config));
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("Via", "1.1 internal-proxy.local")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Internal proxy name should be replaced with pseudonym
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("1.1 firewall")
+    );
+}
+
+#[tokio::test]
+async fn test_via_header_combining_same_protocol() {
+    let config = Rfc9110Config {
+        pseudonym: Some("merged-proxy".to_string()),
+        combine_via: true,
+        ..Default::default()
+    };
+    let app = create_test_app(Some(config));
+
+    let request = Request::builder()
+        .uri("/test")
+        .header(
+            "Via",
+            "1.1 proxy1 (comment1), 1.1 proxy2 (comment2), 1.1 proxy3",
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should combine all 1.1 proxies
+    assert_eq!(
+        response.headers().get("via").unwrap(),
+        HeaderValue::from_static("1.1 merged-proxy")
+    );
+}
+
+#[tokio::test]
+async fn test_unknown_protocol_elements() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .uri("/test")
+        .method("CUSTOM_METHOD") // Non-standard method
+        .header("X-Custom-Protocol", "value") // Non-standard header
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Unknown elements should be forwarded
+    assert!(response.headers().contains_key("x-custom-protocol"));
+}
+
+#[tokio::test]
+async fn test_connection_specific_field_without_connection_header() {
+    let app = create_test_app(None);
+
+    let request = Request::builder()
+        .uri("/test")
+        .header("Proxy-Connection", "keep-alive") // Connection-specific without Connection header
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+
+    // Should be removed even without Connection header
+    assert!(!response.headers().contains_key("proxy-connection"));
+}


### PR DESCRIPTION
Fix Connection header processing, improve Via header combining logic, add firewall mode support, implement Display trait for ViaEntry struct. All tests passing. Fixes #27