### PR TITLE
Remove explicit HTTP1 version setting in proxy.rs

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,5 +1,5 @@
 use axum::body::Body;
-use http::{StatusCode, Version};
+use http::StatusCode;
 use http_body_util::BodyExt;
 use hyper_util::client::legacy::{connect::HttpConnector, Client};
 use std::convert::Infallible;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -135,7 +135,6 @@ impl ReverseProxy {
             let forward_req = {
                 let mut builder = axum::http::Request::builder()
                     .method(req.method().clone())
-                    .version(Version::HTTP_11)
                     .uri(format!(
                         "{}{}",
                         self.target,


### PR DESCRIPTION
Remove the line that sets the HTTP version to HTTP/1.1 in the `proxy_request` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tom-lubenow/axum-reverse-proxy/pull/37?shareId=53476a51-bcfd-4a63-8b4a-8465215d238c).