### PR TITLE
Add support for proxying to HTTPS endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "http 1.2.0",
  "http-body-util",
  "hyper 1.5.2",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "reqwest",
  "serde_json",
@@ -878,6 +879,22 @@ dependencies = [
  "native-tls",
  "tokio 1.42.0",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes 1.9.0",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
+ "native-tls",
+ "tokio 1.42.0",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1589,7 +1606,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ futures-util = "^0.3"
 http = "^1.0"
 http-body-util = "^0.1"
 hyper = { version = "^1.0", features = ["full"] }
+hyper-tls = { version = "^0.6", optional = true }
 hyper-util = { version = "^0.1", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
 sha1 = "^0.10"
 tokio = { version = "^1.35", features = ["full"] }
@@ -37,6 +38,10 @@ tower-buffer = "^0.3"
 tower-http = { version = "^0.5", features = ["full"] }
 tracing-subscriber = { version = "^0.3", features = ["env-filter"] }
 
+[features]
+default = ["tls"]
+tls = ["hyper-tls"]
+
 [[bench]]
 name = "proxy_bench"
 harness = false
@@ -48,11 +53,14 @@ harness = false
 [[example]]
 name = "basic"
 path = "examples/basic.rs"
+features = ["tls"]
 
 [[example]]
 name = "nested"
 path = "examples/nested.rs"
+features = ["tls"]
 
 [[example]]
 name = "tower_middleware"
 path = "examples/tower_middleware.rs"
+features = ["tls"]


### PR DESCRIPTION
I'm not sure whether this never worked or broke during some upgrade, but AFAICT there's no way this could work with just the current `HttpConnector`.

Adresses #43 