### PR TITLE
chore: bump version to 0.8.0 and fix benchmark CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "axum-reverse-proxy"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-reverse-proxy"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "A flexible and efficient reverse proxy implementation for Axum web applications"
 license = "MIT"

--- a/benchmarks/scripts/requirements.txt
+++ b/benchmarks/scripts/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+seaborn
+pandas


### PR DESCRIPTION
- Add requirements.txt for Python dependencies needed in benchmarks
- Bump version from 0.7.0 to 0.8.0 for HTTPS endpoint support
