### PR TITLE
Add Service impl for ReverseProxy

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -1,5 +1,5 @@
 use crate::proxy::ReverseProxy;
-use axum::{extract::State, routing::Router};
+use axum::routing::Router;
 use hyper_util::client::legacy::connect::Connect;
 
 /// Enables conversion from a `ReverseProxy` into an Axum `Router`.
@@ -27,11 +27,7 @@ where
 {
     fn from(proxy: ReverseProxy<C>) -> Self {
         let path = proxy.path().to_string();
-        let proxy_router = Router::new()
-            .fallback(|State(proxy): State<ReverseProxy<C>>, req| async move {
-                proxy.proxy_request(req).await
-            })
-            .with_state(proxy);
+        let proxy_router = Router::<S>::new().fallback_service(proxy);
 
         if ["", "/"].contains(&path.as_str()) {
             proxy_router

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -1,0 +1,71 @@
+use axum::{
+    body::{to_bytes, Body},
+    extract::Json,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use axum_reverse_proxy::ReverseProxy;
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_proxy_service_get() {
+    let app = Router::new().route(
+        "/test",
+        get(|| async { Json(json!({"message": "Hello from test server!"})) }),
+    );
+
+    let test_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let test_addr = test_listener.local_addr().unwrap();
+    let test_server = tokio::spawn(async move {
+        axum::serve(test_listener, app).await.unwrap();
+    });
+
+    let proxy = ReverseProxy::new("/", &format!("http://{}", test_addr));
+
+    let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+    let response = proxy.clone().oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["message"], "Hello from test server!");
+
+    test_server.abort();
+}
+
+#[tokio::test]
+async fn test_proxy_service_post() {
+    let app = Router::new().route(
+        "/echo",
+        post(|body: Json<Value>| async move { Json(body.0) }),
+    );
+
+    let test_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let test_addr = test_listener.local_addr().unwrap();
+    let test_server = tokio::spawn(async move {
+        axum::serve(test_listener, app).await.unwrap();
+    });
+
+    let proxy = ReverseProxy::new("/", &format!("http://{}", test_addr));
+
+    let test_body = json!({"message": "Hello, proxy!"});
+    let request = Request::builder()
+        .method("POST")
+        .uri("/echo")
+        .header("content-type", "application/json")
+        .body(Body::from(test_body.to_string()))
+        .unwrap();
+
+    let response = proxy.clone().oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body, test_body);
+
+    test_server.abort();
+}


### PR DESCRIPTION
## Summary
- implement `tower::Service` for `ReverseProxy`
- expose proxy logic through `Service::call`
- update router conversion to use the new service
- test ReverseProxy directly as a service

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo clippy --fix --allow-dirty --allow-staged -- -D warnings`
- `cargo clippy --bench proxy_bench --fix --allow-dirty --allow-staged -- -D warnings`
- `cargo clippy --bench websocket_bench --fix --allow-dirty --allow-staged -- -D warnings`
- `cargo test`
