### PR TITLE
Make retries optional layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,14 +53,19 @@ harness = false
 [[example]]
 name = "basic"
 path = "examples/basic.rs"
-features = ["tls"]
+required-features = ["tls"]
 
 [[example]]
 name = "nested"
 path = "examples/nested.rs"
-features = ["tls"]
+required-features = ["tls"]
 
 [[example]]
 name = "tower_middleware"
 path = "examples/tower_middleware.rs"
-features = ["tls"]
+required-features = ["tls"]
+
+[[example]]
+name = "retry"
+path = "examples/retry.rs"
+required-features = ["tls"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The eventual goal would be to benchmark ourselves against common reverse proxy l
 ## Features
 
 - 🛣 Path-based routing
-- 🔄 Automatic retry mechanism with exponential backoff
+- 🔄 Optional retry mechanism with exponential backoff
 - 📨 Header forwarding (with host header management)
 - ⚙ Configurable HTTP client settings
 - 🔌 Easy integration with Axum's Router
@@ -146,8 +146,6 @@ let proxy = ReverseProxy::new_with_client("/api", "https://api.example.com", cli
 ## Configuration
 
 The default configuration includes:
-
-- 3 retry attempts with exponential backoff
 - 60-second keepalive timeout
 - 10-second connect timeout
 - TCP nodelay enabled
@@ -159,6 +157,7 @@ The default configuration includes:
 Check out the [examples](examples/) directory for more usage examples:
 
 - [Basic Proxy](examples/nested.rs) - Shows how to set up a basic reverse proxy with path-based routing
+- [Retry Proxy](examples/retry.rs) - Demonstrates enabling retries via `RetryLayer`
 
 ## Contributing
 

--- a/examples/retry.rs
+++ b/examples/retry.rs
@@ -1,0 +1,20 @@
+use axum::{serve, Router};
+use axum_reverse_proxy::{RetryLayer, ReverseProxy};
+use tokio::net::TcpListener;
+use tower::ServiceBuilder;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    // Forward all requests under /api to httpbin
+    let proxy = ReverseProxy::new("/api", "https://httpbin.org");
+
+    // Enable retries
+    let app: Router = proxy.into();
+    let app = app.layer(ServiceBuilder::new().layer(RetryLayer::new(3)));
+
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    println!("Listening on http://127.0.0.1:3000");
+    serve(listener, app).await.unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! It supports:
 //!
 //! - Path-based routing
-//! - Automatic retry mechanism
+//! - Optional retry mechanism via a [`tower::Layer`]
 //! - Header forwarding
 //! - Configurable HTTP client settings
 //! - WebSocket proxying with:
@@ -127,9 +127,11 @@
 //! - Multiple concurrent connections
 
 mod proxy;
+mod retry;
 mod rfc9110;
 mod router;
 mod websocket;
 
 pub use proxy::ReverseProxy;
+pub use retry::RetryLayer;
 pub use rfc9110::{Rfc9110Config, Rfc9110Layer};

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,88 @@
+use axum::body::Body;
+use http::StatusCode;
+use http_body_util::BodyExt;
+use std::convert::Infallible;
+use std::time::Duration;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+pub struct RetryLayer {
+    attempts: usize,
+    delay: Duration,
+}
+
+impl RetryLayer {
+    pub fn new(attempts: usize) -> Self {
+        Self {
+            attempts,
+            delay: Duration::from_millis(500),
+        }
+    }
+
+    pub fn with_delay(attempts: usize, delay: Duration) -> Self {
+        Self { attempts, delay }
+    }
+}
+
+#[derive(Clone)]
+pub struct Retry<S> {
+    inner: S,
+    attempts: usize,
+    delay: Duration,
+}
+
+impl<S> Layer<S> for RetryLayer {
+    type Service = Retry<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Retry {
+            inner,
+            attempts: self.attempts,
+            delay: self.delay,
+        }
+    }
+}
+
+impl<S> Service<axum::http::Request<Body>> for Retry<S>
+where
+    S: Service<
+            axum::http::Request<Body>,
+            Response = axum::http::Response<Body>,
+            Error = Infallible,
+        > + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = axum::http::Response<Body>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: axum::http::Request<Body>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let attempts = self.attempts;
+        let delay = self.delay;
+        Box::pin(async move {
+            let (parts, body) = req.into_parts();
+            let bytes = body.collect().await.unwrap().to_bytes();
+            for attempt in 0..attempts {
+                let req = axum::http::Request::from_parts(parts.clone(), Body::from(bytes.clone()));
+                let res = inner.call(req).await?;
+                if res.status() != StatusCode::BAD_GATEWAY || attempt == attempts - 1 {
+                    return Ok(res);
+                }
+                tokio::time::sleep(delay).await;
+            }
+            unreachable!();
+        })
+    }
+}

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -71,11 +71,10 @@ async fn test_proxy_error_handling() {
     let response = client
         .get(format!("http://{}/test", proxy_addr))
         .send()
-        .await;
+        .await
+        .unwrap();
 
-    assert!(response.is_err());
-    let err = response.unwrap_err();
-    assert!(err.is_timeout() || err.is_connect());
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_GATEWAY);
 
     // Clean up
     proxy_server.abort();

--- a/tests/retry.rs
+++ b/tests/retry.rs
@@ -1,0 +1,75 @@
+use axum::{routing::get, Router};
+use axum_reverse_proxy::{RetryLayer, ReverseProxy};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tower::ServiceBuilder;
+
+async fn delayed_server(addr: std::net::SocketAddr) {
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let app = Router::new().route("/test", get(|| async { "ok" }));
+    let listener = TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_no_retry_by_default() {
+    // Reserve an address and then release it
+    let temp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = temp.local_addr().unwrap();
+    drop(temp);
+
+    let proxy = ReverseProxy::new("/", &format!("http://{}", addr));
+    let app: Router = proxy.into();
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let proxy_server = tokio::spawn(async move {
+        axum::serve(proxy_listener, app).await.unwrap();
+    });
+
+    // Spawn server after delay
+    let server_handle = tokio::spawn(delayed_server(addr));
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{}/test", proxy_addr))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_GATEWAY);
+
+    proxy_server.abort();
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn test_retry_layer() {
+    let temp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = temp.local_addr().unwrap();
+    drop(temp);
+
+    let proxy = ReverseProxy::new("/", &format!("http://{}", addr));
+    let app: Router = proxy.into();
+    let app = app.layer(ServiceBuilder::new().layer(RetryLayer::new(5)));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let proxy_server = tokio::spawn(async move {
+        axum::serve(proxy_listener, app).await.unwrap();
+    });
+
+    let server_handle = tokio::spawn(delayed_server(addr));
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{}/test", proxy_addr))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    proxy_server.abort();
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary
- extract retry logic into `RetryLayer`
- remove built-in retries from proxy
- document the optional retry layer and add retry example
- add tests confirming default behavior and layer-based retries
- fix example `required-features`

## Testing
- `./check.sh`