### PR TITLE
Fix zero attempts in RetryLayer

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -18,6 +18,7 @@ pub struct RetryLayer {
 
 impl RetryLayer {
     pub fn new(attempts: usize) -> Self {
+        let attempts = attempts.max(1);
         Self {
             attempts,
             delay: Duration::from_millis(500),
@@ -25,6 +26,7 @@ impl RetryLayer {
     }
 
     pub fn with_delay(attempts: usize, delay: Duration) -> Self {
+        let attempts = attempts.max(1);
         Self { attempts, delay }
     }
 }

--- a/tests/retry.rs
+++ b/tests/retry.rs
@@ -73,3 +73,34 @@ async fn test_retry_layer() {
     proxy_server.abort();
     server_handle.abort();
 }
+
+#[tokio::test]
+async fn test_retry_layer_zero_attempts() {
+    let temp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = temp.local_addr().unwrap();
+    drop(temp);
+
+    let proxy = ReverseProxy::new("/", &format!("http://{}", addr));
+    let app: Router = proxy.into();
+    let app = app.layer(ServiceBuilder::new().layer(RetryLayer::new(0)));
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let proxy_server = tokio::spawn(async move {
+        axum::serve(proxy_listener, app).await.unwrap();
+    });
+
+    let server_handle = tokio::spawn(delayed_server(addr));
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{}/test", proxy_addr))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_GATEWAY);
+
+    proxy_server.abort();
+    server_handle.abort();
+}


### PR DESCRIPTION
## Summary
- ensure `RetryLayer` uses at least one attempt
- test that a layer created with zero attempts still functions

## Testing
- `./check.sh`