### PR TITLE
Improve header comparisons

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -32,9 +32,8 @@ pub(crate) fn is_websocket_upgrade(headers: &HeaderMap<HeaderValue>) -> bool {
         .get("connection")
         .and_then(|v| v.to_str().ok())
         .map(|v| {
-            v.to_ascii_lowercase()
-                .split(',')
-                .any(|part| part.trim() == "upgrade")
+            v.split(',')
+                .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
         })
         .unwrap_or(false);
 


### PR DESCRIPTION
## Summary
- use `eq_ignore_ascii_case` for header name comparisons
- define a static hop-by-hop header slice and reference it
- update WebSocket upgrade detection

## Testing
- `./check.sh`