### PR TITLE
Add BalancedProxy for round-robin load balancing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,8 @@ required-features = ["tls"]
 name = "retry"
 path = "examples/retry.rs"
 required-features = ["tls"]
+
+[[example]]
+name = "balanced"
+path = "examples/balanced.rs"
+required-features = ["tls"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The eventual goal would be to benchmark ourselves against common reverse proxy l
 - 🔄 Optional retry mechanism with exponential backoff
 - 📨 Header forwarding (with host header management)
 - ⚙ Configurable HTTP client settings
+- 🔀 Round-robin load balancing across multiple upstreams
 - 🔌 Easy integration with Axum's Router
 - 🧰 Custom client configuration support
 - 🔒 HTTPS support
@@ -36,6 +37,16 @@ use axum_reverse_proxy::ReverseProxy;
 let proxy = ReverseProxy::new("/api", "https://httpbin.org");
 
 // Convert the proxy to a router and use it in your Axum application
+let app: Router = proxy.into();
+```
+
+### Load Balanced Upstreams
+
+```rust
+use axum::Router;
+use axum_reverse_proxy::BalancedProxy;
+
+let proxy = BalancedProxy::new("/api", vec!["https://api1.example.com", "https://api2.example.com"]);
 let app: Router = proxy.into();
 ```
 
@@ -64,6 +75,7 @@ use tower_buffer::BufferLayer;
 
 let proxy = ReverseProxy::new("/api", "https://api.example.com");
 let app: Router = proxy.into();
+
 
 // Add buffering middleware
 let app = app.layer(ServiceBuilder::new().layer(BufferLayer::new(100)));
@@ -158,6 +170,7 @@ Check out the [examples](examples/) directory for more usage examples:
 
 - [Basic Proxy](examples/nested.rs) - Shows how to set up a basic reverse proxy with path-based routing
 - [Retry Proxy](examples/retry.rs) - Demonstrates enabling retries via `RetryLayer`
+- [Balanced Proxy](examples/balanced.rs) - Forward to multiple upstream servers with round-robin load balancing
 - **Note:** very large requests may still need buffering depending on the body wrapper's strategy.
 
 ## Contributing

--- a/examples/balanced.rs
+++ b/examples/balanced.rs
@@ -1,0 +1,17 @@
+use axum::{serve, Router};
+use axum_reverse_proxy::BalancedProxy;
+use tokio::net::TcpListener;
+
+#[tokio::main]
+async fn main() {
+    // Forward /api to two upstream servers
+    let proxy = BalancedProxy::new(
+        "/api",
+        vec!["https://api1.example.com", "https://api2.example.com"],
+    );
+    let app: Router = proxy.into();
+
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    println!("Server running on http://localhost:3000");
+    serve(listener, app).await.unwrap();
+}

--- a/src/balanced_proxy.rs
+++ b/src/balanced_proxy.rs
@@ -1,0 +1,108 @@
+use axum::body::Body;
+#[cfg(feature = "tls")]
+use hyper_tls::HttpsConnector;
+use hyper_util::client::legacy::{
+    connect::{Connect, HttpConnector},
+    Client,
+};
+use std::convert::Infallible;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tracing::trace;
+
+use crate::proxy::ReverseProxy;
+
+#[derive(Clone)]
+pub struct BalancedProxy<C: Connect + Clone + Send + Sync + 'static> {
+    path: String,
+    proxies: Vec<ReverseProxy<C>>,
+    counter: Arc<AtomicUsize>,
+}
+
+#[cfg(feature = "tls")]
+pub type StandardBalancedProxy = BalancedProxy<HttpsConnector<HttpConnector>>;
+#[cfg(not(feature = "tls"))]
+pub type StandardBalancedProxy = BalancedProxy<HttpConnector>;
+
+impl StandardBalancedProxy {
+    pub fn new<S>(path: S, targets: Vec<S>) -> Self
+    where
+        S: Into<String> + Clone,
+    {
+        let mut connector = HttpConnector::new();
+        connector.set_nodelay(true);
+        connector.enforce_http(false);
+        connector.set_keepalive(Some(std::time::Duration::from_secs(60)));
+        connector.set_connect_timeout(Some(std::time::Duration::from_secs(10)));
+        connector.set_reuse_address(true);
+
+        #[cfg(feature = "tls")]
+        let connector = HttpsConnector::new_with_connector(connector);
+
+        let client = Client::builder(hyper_util::rt::TokioExecutor::new())
+            .pool_idle_timeout(std::time::Duration::from_secs(60))
+            .pool_max_idle_per_host(32)
+            .retry_canceled_requests(true)
+            .set_host(true)
+            .build(connector);
+
+        Self::new_with_client(path, targets, client)
+    }
+}
+
+impl<C> BalancedProxy<C>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+{
+    pub fn new_with_client<S>(path: S, targets: Vec<S>, client: Client<C, Body>) -> Self
+    where
+        S: Into<String> + Clone,
+    {
+        let path = path.into();
+        let proxies = targets
+            .into_iter()
+            .map(|t| ReverseProxy::new_with_client(path.clone(), t.into(), client.clone()))
+            .collect();
+
+        Self {
+            path,
+            proxies,
+            counter: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn next_proxy(&self) -> ReverseProxy<C> {
+        let idx = self.counter.fetch_add(1, Ordering::SeqCst) % self.proxies.len();
+        self.proxies[idx].clone()
+    }
+}
+
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::Service;
+
+impl<C> Service<axum::http::Request<Body>> for BalancedProxy<C>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+{
+    type Response = axum::http::Response<Body>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: axum::http::Request<Body>) -> Self::Future {
+        let mut proxy = self.next_proxy();
+        trace!("balanced proxying via upstream {}", proxy.target());
+        Box::pin(async move { proxy.call(req).await })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! - Optional retry mechanism via a [`tower::Layer`]
 //! - Header forwarding
 //! - Configurable HTTP client settings
+//! - Round-robin load balancing across multiple upstreams
 //! - WebSocket proxying with:
 //!   - Automatic upgrade handling
 //!   - Bidirectional message forwarding
@@ -26,6 +27,16 @@
 //! let proxy = ReverseProxy::new("/api", "https://httpbin.org");
 //!
 //! // Convert the proxy to a router and use it in your Axum application
+//! let app: Router = proxy.into();
+//! ```
+//!
+//! # Load Balanced Example
+//!
+//! ```rust
+//! use axum::Router;
+//! use axum_reverse_proxy::BalancedProxy;
+//!
+//! let proxy = BalancedProxy::new("/api", vec!["https://api1.example.com", "https://api2.example.com"]);
 //! let app: Router = proxy.into();
 //! ```
 //!
@@ -126,12 +137,15 @@
 //! - Connection close frames
 //! - Multiple concurrent connections
 
+mod balanced_proxy;
 mod proxy;
 mod retry;
 mod rfc9110;
 mod router;
 mod websocket;
 
+pub use balanced_proxy::BalancedProxy;
+pub use balanced_proxy::StandardBalancedProxy;
 pub use proxy::ReverseProxy;
 pub use retry::RetryLayer;
 pub use rfc9110::{Rfc9110Config, Rfc9110Layer};

--- a/src/router.rs
+++ b/src/router.rs
@@ -36,3 +36,22 @@ where
         }
     }
 }
+
+use crate::balanced_proxy::BalancedProxy;
+
+impl<C, S> From<BalancedProxy<C>> for Router<S>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+    S: Send + Sync + Clone + 'static,
+{
+    fn from(proxy: BalancedProxy<C>) -> Self {
+        let path = proxy.path().to_string();
+        let proxy_router = Router::<S>::new().fallback_service(proxy);
+
+        if ["", "/"].contains(&path.as_str()) {
+            proxy_router
+        } else {
+            Router::new().nest(&path, proxy_router)
+        }
+    }
+}

--- a/tests/balanced.rs
+++ b/tests/balanced.rs
@@ -1,0 +1,43 @@
+use axum::{extract::Json, http::StatusCode, routing::get, Router};
+use axum_reverse_proxy::BalancedProxy;
+use serde_json::json;
+use serde_json::Value;
+use tokio::net::TcpListener;
+
+#[tokio::test]
+async fn test_round_robin_distribution() {
+    let app1 = Router::new().route("/", get(|| async { Json(json!({"server": 1})) }));
+    let listener1 = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr1 = listener1.local_addr().unwrap();
+    let server1 = tokio::spawn(async move { axum::serve(listener1, app1).await.unwrap() });
+
+    let app2 = Router::new().route("/", get(|| async { Json(json!({"server": 2})) }));
+    let listener2 = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr2 = listener2.local_addr().unwrap();
+    let server2 = tokio::spawn(async move { axum::serve(listener2, app2).await.unwrap() });
+    let proxy = BalancedProxy::new(
+        String::from("/"),
+        vec![format!("http://{}", addr1), format!("http://{}", addr2)],
+    );
+    let app: Router = proxy.into();
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    let proxy_server = tokio::spawn(async move { axum::serve(proxy_listener, app).await.unwrap() });
+
+    let client = reqwest::Client::new();
+    for expected in [1, 2, 1, 2] {
+        let res = client
+            .get(format!("http://{}/", proxy_addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status().as_u16(), StatusCode::OK.as_u16());
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["server"], expected);
+    }
+
+    proxy_server.abort();
+    server1.abort();
+    server2.abort();
+}


### PR DESCRIPTION
## Summary
- introduce `BalancedProxy` for round-robin load balancing
- hook `BalancedProxy` into router conversion
- document new API and add example
- add `balanced` example to Cargo.toml
- test round-robin behavior

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo clippy --fix --allow-dirty --allow-staged -- -D warnings`
- `cargo test`
