### PR TITLE
feat: Add support for bypassing SSL/TLS certificate verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "axum-reverse-proxy"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-stream",
  "axum",
@@ -212,11 +212,16 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
+ "native-tls",
  "rand 0.9.1",
+ "rcgen",
  "reqwest",
+ "rustls",
  "serde_json",
  "sha1",
  "tokio 1.45.1",
+ "tokio-native-tls",
+ "tokio-rustls",
  "tokio-tungstenite 0.21.0",
  "tower",
  "tower-buffer",
@@ -588,6 +593,15 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1571,6 +1585,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +1790,12 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1881,6 +1917,19 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -2432,6 +2481,25 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
@@ -3277,6 +3345,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-reverse-proxy"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 description = "A flexible and efficient reverse proxy implementation for Axum web applications"
 license = "MIT"
@@ -23,8 +23,11 @@ hyper = { version = "^1.0", features = ["full"] }
 hyper-rustls = { version = "^0.27", optional = true }
 hyper-tls = { version = "^0.6", optional = true }
 hyper-util = { version = "^0.1", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
+native-tls = { version = "^0.2", optional = true }
+rustls = { version = "^0.23", optional = true }
 sha1 = "^0.10"
 tokio = { version = "^1.45", features = ["full"] }
+tokio-native-tls = { version = "^0.3", optional = true }
 tokio-tungstenite = "^0.21"
 tower = { version = "^0.5", features = ["full"] }
 tracing = "^0.1"
@@ -35,17 +38,19 @@ rand = "0.9.1"
 [dev-dependencies]
 async-stream = "^0.3"
 criterion = { version = "^0.5", features = ["async", "futures"] }
+rcgen = "^0.13"
 reqwest = { version = "^0.11", features = ["json"] }
 serde_json = "^1.0"
 tokio = { version = "^1.45", features = ["full", "test-util"] }
+tokio-rustls = "^0.26"
 tower-buffer = "^0.3"
 tower-http = { version = "^0.6", features = ["full"] }
 tracing-subscriber = { version = "^0.3", features = ["env-filter"] }
 
 [features]
 default = ["tls"]
-tls = ["hyper-rustls"]
-native-tls = ["hyper-tls"]
+tls = ["hyper-rustls", "rustls"]
+native-tls = ["hyper-tls", "dep:native-tls", "tokio-native-tls"]
 dns = ["hickory-resolver"]
 full = ["tls", "dns"]
 
@@ -96,3 +101,8 @@ required-features = ["tls"]
 name = "dns_discovery"
 path = "examples/dns_discovery.rs"
 required-features = ["tls", "dns"]
+
+[[example]]
+name = "dangerous_client"
+path = "examples/dangerous_client.rs"
+required-features = ["tls"]

--- a/examples/dangerous_client.rs
+++ b/examples/dangerous_client.rs
@@ -1,0 +1,107 @@
+//! Example of creating HTTPS clients that accept invalid certificates.
+//!
+//! WARNING: This should only be used for development/testing purposes!
+
+use axum::{Router, routing::get};
+use std::net::SocketAddr;
+
+#[tokio::main]
+async fn main() {
+    // Initialize tracing
+    tracing_subscriber::fmt::init();
+
+    println!("⚠️  Dangerous HTTPS Client Example");
+    println!("==================================");
+    println!();
+    println!("This example shows how to create HTTPS clients that accept invalid certificates.");
+    println!("This should ONLY be used for development/testing with self-signed certificates!");
+    println!();
+
+    // Example for rustls (default TLS backend)
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    {
+        use axum_reverse_proxy::create_dangerous_rustls_config;
+        use bytes::Bytes;
+        use http_body_util::Empty;
+        use hyper_rustls::HttpsConnectorBuilder;
+        use hyper_util::client::legacy::Client;
+        use hyper_util::rt::TokioExecutor;
+
+        println!("Creating dangerous client with rustls...");
+
+        // Create the dangerous TLS config
+        let tls_config = create_dangerous_rustls_config();
+
+        // Build HTTPS connector
+        let https = HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        // Create the client
+        let _client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        println!("✓ Created hyper client that accepts invalid certificates");
+
+        // Example usage:
+        // let response = client
+        //     .request(Request::get("https://self-signed.example.com")
+        //         .body(Body::empty())
+        //         .unwrap())
+        //     .await
+        //     .unwrap();
+    }
+
+    // Example for native-tls
+    #[cfg(feature = "native-tls")]
+    {
+        use axum_reverse_proxy::create_dangerous_native_tls_connector;
+        use bytes::Bytes;
+        use http_body_util::Empty;
+        use hyper_tls::HttpsConnector;
+        use hyper_util::client::legacy::{Client, connect::HttpConnector};
+        use hyper_util::rt::TokioExecutor;
+
+        println!("Creating dangerous client with native-tls...");
+
+        // Create the dangerous TLS connector
+        let tls = create_dangerous_native_tls_connector().expect("Failed to create TLS connector");
+
+        // Create HTTP connector
+        let mut http = HttpConnector::new();
+        http.enforce_http(false);
+
+        // Convert to tokio connector
+        let tls = tokio_native_tls::TlsConnector::from(tls);
+
+        // Create HTTPS connector
+        let https = HttpsConnector::from((http, tls));
+
+        // Create the client
+        let _client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        println!("✓ Created hyper client that accepts invalid certificates");
+    }
+
+    println!();
+    println!("You can now use these clients to connect to servers with:");
+    println!("- Self-signed certificates");
+    println!("- Expired certificates");
+    println!("- Wrong hostname certificates");
+    println!("- Untrusted CA certificates");
+    println!();
+
+    // Simple server to keep the example running
+    async fn root() -> &'static str {
+        "Dangerous client example server"
+    }
+
+    let app = Router::new().route("/", get(root));
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    println!("Example server listening on {}", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/src/danger.rs
+++ b/src/danger.rs
@@ -1,0 +1,98 @@
+//! Utilities for creating HTTPS clients that accept invalid certificates.
+//!
+//! # Security Warning
+//!
+//! These utilities completely disable certificate validation, making connections
+//! vulnerable to man-in-the-middle attacks. Only use in development/testing environments.
+
+#[cfg(all(feature = "tls", not(feature = "native-tls")))]
+use rustls::ClientConfig;
+
+#[cfg(feature = "native-tls")]
+use native_tls::TlsConnector;
+
+/// Creates a rustls ClientConfig that accepts any certificate.
+///
+/// # Security Warning
+///
+/// This configuration will accept ANY certificate, including:
+/// - Self-signed certificates
+/// - Expired certificates  
+/// - Certificates with wrong hostnames
+/// - Certificates from untrusted CAs
+///
+/// Only use this for development or testing!
+#[cfg(all(feature = "tls", not(feature = "native-tls")))]
+pub fn create_dangerous_rustls_config() -> ClientConfig {
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    struct NoCertificateVerification;
+
+    impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &rustls::pki_types::CertificateDer<'_>,
+            _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+            _server_name: &rustls::pki_types::ServerName,
+            _ocsp_response: &[u8],
+            _now: rustls::pki_types::UnixTime,
+        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &rustls::pki_types::CertificateDer<'_>,
+            _dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            _message: &[u8],
+            _cert: &rustls::pki_types::CertificateDer<'_>,
+            _dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            // Support all signature schemes
+            vec![
+                rustls::SignatureScheme::RSA_PKCS1_SHA256,
+                rustls::SignatureScheme::RSA_PKCS1_SHA384,
+                rustls::SignatureScheme::RSA_PKCS1_SHA512,
+                rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+                rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+                rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+                rustls::SignatureScheme::RSA_PSS_SHA256,
+                rustls::SignatureScheme::RSA_PSS_SHA384,
+                rustls::SignatureScheme::RSA_PSS_SHA512,
+                rustls::SignatureScheme::ED25519,
+                rustls::SignatureScheme::RSA_PKCS1_SHA1,
+                rustls::SignatureScheme::ECDSA_SHA1_Legacy,
+            ]
+        }
+    }
+
+    ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
+        .with_no_client_auth()
+}
+
+/// Creates a native-tls TlsConnector that accepts any certificate.
+///
+/// # Security Warning
+///
+/// This connector will accept ANY certificate. Only use for development or testing!
+#[cfg(feature = "native-tls")]
+pub fn create_dangerous_native_tls_connector() -> Result<TlsConnector, native_tls::Error> {
+    TlsConnector::builder()
+        .danger_accept_invalid_certs(true)
+        .danger_accept_invalid_hostnames(true)
+        .build()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,8 @@
 //! The `native-tls` feature is a separate opt-in and is not included in the `full` feature set.
 
 mod balanced_proxy;
+#[cfg(any(feature = "tls", feature = "native-tls"))]
+mod danger;
 #[cfg(feature = "dns")]
 mod dns_discovery;
 mod proxy;
@@ -316,6 +318,10 @@ pub use balanced_proxy::DiscoverableBalancedProxy;
 pub use balanced_proxy::LoadBalancingStrategy;
 pub use balanced_proxy::StandardBalancedProxy;
 pub use balanced_proxy::StandardDiscoverableBalancedProxy;
+#[cfg(feature = "native-tls")]
+pub use danger::create_dangerous_native_tls_connector;
+#[cfg(all(feature = "tls", not(feature = "native-tls")))]
+pub use danger::create_dangerous_rustls_config;
 #[cfg(feature = "dns")]
 pub use dns_discovery::{DnsDiscovery, DnsDiscoveryConfig, StaticDnsDiscovery};
 pub use proxy::ReverseProxy;

--- a/tests/badssl_integration_test.rs
+++ b/tests/badssl_integration_test.rs
@@ -1,0 +1,224 @@
+//! Integration tests against badssl.com endpoints
+//!
+//! These tests verify that our dangerous HTTPS clients work correctly
+//! with various types of invalid certificates in real-world scenarios.
+
+#[cfg(any(feature = "tls", feature = "native-tls"))]
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use http_body_util::Empty;
+    use hyper::{Request, StatusCode};
+    use hyper_util::client::legacy::Client;
+    use hyper_util::rt::TokioExecutor;
+
+    #[cfg(feature = "native-tls")]
+    use axum_reverse_proxy::create_dangerous_native_tls_connector;
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    use axum_reverse_proxy::create_dangerous_rustls_config;
+
+    // Helper to check if we got a successful response or a redirect
+    fn is_success_or_redirect(status: StatusCode) -> bool {
+        status.is_success() || status.is_redirection()
+    }
+
+    #[tokio::test]
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    async fn test_rustls_self_signed_cert() {
+        let tls_config = create_dangerous_rustls_config();
+        let https = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        let response = client
+            .request(
+                Request::get("https://self-signed.badssl.com/")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap(),
+            )
+            .await
+            .expect("Should connect to self-signed cert");
+
+        assert!(is_success_or_redirect(response.status()));
+    }
+
+    #[tokio::test]
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    async fn test_rustls_wrong_host() {
+        let tls_config = create_dangerous_rustls_config();
+        let https = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        let response = client
+            .request(
+                Request::get("https://wrong.host.badssl.com/")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap(),
+            )
+            .await
+            .expect("Should connect to wrong hostname cert");
+
+        assert!(is_success_or_redirect(response.status()));
+    }
+
+    #[tokio::test]
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    async fn test_rustls_untrusted_root() {
+        let tls_config = create_dangerous_rustls_config();
+        let https = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        let response = client
+            .request(
+                Request::get("https://untrusted-root.badssl.com/")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap(),
+            )
+            .await
+            .expect("Should connect to untrusted root cert");
+
+        assert!(is_success_or_redirect(response.status()));
+    }
+
+    #[tokio::test]
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    async fn test_rustls_expired_cert() {
+        let tls_config = create_dangerous_rustls_config();
+        let https = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        let response = client
+            .request(
+                Request::get("https://expired.badssl.com/")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap(),
+            )
+            .await
+            .expect("Should connect to expired cert");
+
+        assert!(is_success_or_redirect(response.status()));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "native-tls")]
+    async fn test_native_tls_self_signed_cert() {
+        let tls = create_dangerous_native_tls_connector()
+            .expect("Failed to create dangerous TLS connector");
+
+        let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
+        http.enforce_http(false);
+
+        let tls = tokio_native_tls::TlsConnector::from(tls);
+        let https = hyper_tls::HttpsConnector::from((http, tls));
+
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        let response = client
+            .request(
+                Request::get("https://self-signed.badssl.com/")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap(),
+            )
+            .await
+            .expect("Should connect to self-signed cert");
+
+        assert!(is_success_or_redirect(response.status()));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "native-tls")]
+    async fn test_native_tls_wrong_host() {
+        let tls = create_dangerous_native_tls_connector()
+            .expect("Failed to create dangerous TLS connector");
+
+        let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
+        http.enforce_http(false);
+
+        let tls = tokio_native_tls::TlsConnector::from(tls);
+        let https = hyper_tls::HttpsConnector::from((http, tls));
+
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        let response = client
+            .request(
+                Request::get("https://wrong.host.badssl.com/")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap(),
+            )
+            .await
+            .expect("Should connect to wrong hostname cert");
+
+        assert!(is_success_or_redirect(response.status()));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "native-tls")]
+    async fn test_native_tls_untrusted_root() {
+        let tls = create_dangerous_native_tls_connector()
+            .expect("Failed to create dangerous TLS connector");
+
+        let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
+        http.enforce_http(false);
+
+        let tls = tokio_native_tls::TlsConnector::from(tls);
+        let https = hyper_tls::HttpsConnector::from((http, tls));
+
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        let response = client
+            .request(
+                Request::get("https://untrusted-root.badssl.com/")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap(),
+            )
+            .await
+            .expect("Should connect to untrusted root cert");
+
+        assert!(is_success_or_redirect(response.status()));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "native-tls")]
+    async fn test_native_tls_expired_cert() {
+        let tls = create_dangerous_native_tls_connector()
+            .expect("Failed to create dangerous TLS connector");
+
+        let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
+        http.enforce_http(false);
+
+        let tls = tokio_native_tls::TlsConnector::from(tls);
+        let https = hyper_tls::HttpsConnector::from((http, tls));
+
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        let response = client
+            .request(
+                Request::get("https://expired.badssl.com/")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap(),
+            )
+            .await
+            .expect("Should connect to expired cert");
+
+        assert!(is_success_or_redirect(response.status()));
+    }
+}

--- a/tests/dangerous_client_test.rs
+++ b/tests/dangerous_client_test.rs
@@ -1,0 +1,233 @@
+#[cfg(any(feature = "tls", feature = "native-tls"))]
+#[cfg(test)]
+mod tests {
+    use axum::{Router, routing::get};
+    use bytes::Bytes;
+    use http_body_util::{BodyExt, Empty};
+    use hyper::{Request, StatusCode};
+    use hyper_util::client::legacy::Client;
+    use hyper_util::rt::TokioExecutor;
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+    use tower::ServiceExt;
+
+    #[cfg(feature = "native-tls")]
+    use axum_reverse_proxy::create_dangerous_native_tls_connector;
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    use axum_reverse_proxy::create_dangerous_rustls_config;
+
+    // Create a test server with self-signed certificate
+    async fn start_https_test_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+        use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+        use tokio_rustls::TlsAcceptor;
+
+        // Generate self-signed certificate for testing
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let cert_der = CertificateDer::from(cert.cert);
+        let key_der = PrivateKeyDer::try_from(cert.key_pair.serialize_der()).unwrap();
+
+        let mut config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert_der], key_der)
+            .unwrap();
+
+        // Set ALPN protocols for HTTP/1.1
+        config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+        let acceptor = TlsAcceptor::from(Arc::new(config));
+
+        let app = Router::new().route("/", get(|| async { "Hello from self-signed HTTPS server" }));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                let acceptor = acceptor.clone();
+                let app = app.clone();
+
+                tokio::spawn(async move {
+                    if let Ok(stream) = acceptor.accept(stream).await {
+                        let _ = hyper::server::conn::http1::Builder::new()
+                            .serve_connection(
+                                hyper_util::rt::TokioIo::new(stream),
+                                hyper::service::service_fn(move |req| {
+                                    let app = app.clone();
+                                    async move { app.oneshot(req).await }
+                                }),
+                            )
+                            .await;
+                    }
+                });
+            }
+        });
+
+        // Give server time to start
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        (addr, handle)
+    }
+
+    #[tokio::test]
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    async fn test_dangerous_rustls_accepts_self_signed_cert() {
+        // Start HTTPS server with self-signed certificate
+        let (addr, server_handle) = start_https_test_server().await;
+
+        // Create dangerous rustls config
+        let tls_config = create_dangerous_rustls_config();
+
+        // Build HTTPS connector with dangerous config
+        let https = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        // Create client
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        // Make request to self-signed server - should succeed with dangerous config
+        let uri = format!("https://localhost:{}/", addr.port());
+        let response = client
+            .request(Request::get(uri).body(Empty::<Bytes>::new()).unwrap())
+            .await
+            .expect("Request should succeed with dangerous config");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body, "Hello from self-signed HTTPS server");
+
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    async fn test_normal_rustls_rejects_self_signed_cert() {
+        // Start HTTPS server with self-signed certificate
+        let (addr, server_handle) = start_https_test_server().await;
+
+        // Create normal rustls config (with proper verification)
+        let tls_config = rustls::ClientConfig::builder()
+            .with_root_certificates(rustls::RootCertStore::empty())
+            .with_no_client_auth();
+
+        // Build HTTPS connector with normal config
+        let https = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        // Create client
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        // Make request to self-signed server - should fail with normal config
+        let uri = format!("https://localhost:{}/", addr.port());
+        let result = client
+            .request(Request::get(uri).body(Empty::<Bytes>::new()).unwrap())
+            .await;
+
+        // Should fail due to certificate verification
+        assert!(result.is_err(), "Request should fail with normal config");
+
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "native-tls")]
+    async fn test_dangerous_native_tls_accepts_self_signed_cert() {
+        // Start HTTPS server with self-signed certificate
+        let (addr, server_handle) = start_https_test_server().await;
+
+        // Create dangerous native-tls connector
+        let tls = create_dangerous_native_tls_connector()
+            .expect("Failed to create dangerous TLS connector");
+
+        // Create HTTP connector
+        let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
+        http.enforce_http(false);
+
+        // Convert to tokio connector
+        let tls = tokio_native_tls::TlsConnector::from(tls);
+
+        // Create HTTPS connector
+        let https = hyper_tls::HttpsConnector::from((http, tls));
+
+        // Create client
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        // Make request to self-signed server - should succeed with dangerous config
+        let uri = format!("https://localhost:{}/", addr.port());
+        let response = client
+            .request(Request::get(uri).body(Empty::<Bytes>::new()).unwrap())
+            .await
+            .expect("Request should succeed with dangerous config");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body, "Hello from self-signed HTTPS server");
+
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "native-tls")]
+    async fn test_normal_native_tls_rejects_self_signed_cert() {
+        // Start HTTPS server with self-signed certificate
+        let (addr, server_handle) = start_https_test_server().await;
+
+        // Create normal native-tls connector (with proper verification)
+        let tls = native_tls::TlsConnector::new().expect("Failed to create TLS connector");
+
+        // Create HTTP connector
+        let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
+        http.enforce_http(false);
+
+        // Convert to tokio connector
+        let tls = tokio_native_tls::TlsConnector::from(tls);
+
+        // Create HTTPS connector
+        let https = hyper_tls::HttpsConnector::from((http, tls));
+
+        // Create client
+        let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
+
+        // Make request to self-signed server - should fail with normal config
+        let uri = format!("https://localhost:{}/", addr.port());
+        let result = client
+            .request(Request::get(uri).body(Empty::<Bytes>::new()).unwrap())
+            .await;
+
+        // Should fail due to certificate verification
+        assert!(result.is_err(), "Request should fail with normal config");
+
+        server_handle.abort();
+    }
+
+    #[test]
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
+    fn test_dangerous_rustls_config_properties() {
+        // Test that the dangerous config has expected properties
+        let config = create_dangerous_rustls_config();
+
+        // Config was created successfully - the dangerous verifier is installed
+        drop(config);
+    }
+
+    #[test]
+    #[cfg(feature = "native-tls")]
+    fn test_dangerous_native_tls_connector_creation() {
+        // Test that we can create a dangerous native-tls connector
+        let connector = create_dangerous_native_tls_connector()
+            .expect("Failed to create dangerous TLS connector");
+
+        // We can't easily test the internal state of native-tls,
+        // but we verified it accepts self-signed certs in the integration test above
+        drop(connector);
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the functionality requested in #91 to support bypassing SSL/TLS certificate verification for HTTPS connections, similar to reqwest's `danger_accept_invalid_certs` option.

## Implementation

The implementation provides simple helper functions that create TLS configurations which bypass certificate validation:

- **`create_dangerous_rustls_config()`** - Returns a rustls `ClientConfig` that accepts any certificate
- **`create_dangerous_native_tls_connector()`** - Returns a native-tls `TlsConnector` with danger flags enabled

These can be used with hyper's `HttpsConnectorBuilder` to create clients that bypass certificate validation.

## Key Design Decisions

1. **Minimal API Surface**: Instead of creating complex wrapper types, we provide simple helper functions that return standard TLS configurations
2. **Maximum Flexibility**: Users can configure their own HTTP connectors and body types
3. **Feature Compatibility**: Works with both `tls` (rustls) and `native-tls` features
4. **Clear Security Warning**: All dangerous functionality is clearly marked with warnings in documentation

## Testing

- ✅ Unit tests with local self-signed certificate server
- ✅ Integration tests against badssl.com endpoints (self-signed, expired, wrong hostname, untrusted root)
- ✅ Tests for both rustls and native-tls implementations
- ✅ All tests pass
- ✅ Code formatted with `cargo fmt`
- ✅ No clippy warnings

## Example Usage

```rust
use axum_reverse_proxy::create_dangerous_rustls_config;
use hyper_rustls::HttpsConnectorBuilder;
use hyper_util::client::legacy::Client;

// Create dangerous TLS config
let tls_config = create_dangerous_rustls_config();

// Build HTTPS connector
let https = HttpsConnectorBuilder::new()
    .with_tls_config(tls_config)
    .https_or_http()
    .enable_http1()
    .build();

// Create client that accepts invalid certificates
let client = Client::builder(TokioExecutor::new()).build(https);
```

## Security Considerations

⚠️ **WARNING**: These utilities completely disable certificate validation, making connections vulnerable to man-in-the-middle attacks. They should ONLY be used for development/testing purposes with self-signed certificates.

Closes #91