### PR TITLE
Fix clippy warnings and standardize feature flags in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --features full -- -D warnings
       - name: Check benchmarks with clippy
         run: cargo clippy --benches -- -D warnings
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
           fi
       
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --features full
       
       - name: Run doc tests
         run: cargo test --doc
@@ -57,7 +57,7 @@ jobs:
         run: cargo fmt --all -- --check
       
       - name: Run clippy
-        run: cargo clippy --all-features -- -D warnings
+        run: cargo clippy --features full -- -D warnings
       
       - name: Publish dry run
         run: cargo publish --dry-run

--- a/src/dns_discovery.rs
+++ b/src/dns_discovery.rs
@@ -101,7 +101,7 @@ impl DnsDiscovery {
             .build()
         } else {
             Resolver::builder_tokio()
-                .map_err(|e| format!("Failed to create resolver from system config: {}", e))?
+                .map_err(|e| format!("Failed to create resolver from system config: {e}"))?
                 .build()
         };
 
@@ -232,7 +232,7 @@ impl StaticDnsDiscovery {
             .build()
         } else {
             Resolver::builder_tokio()
-                .map_err(|e| format!("Failed to create resolver from system config: {}", e))?
+                .map_err(|e| format!("Failed to create resolver from system config: {e}"))?
                 .build()
         };
 


### PR DESCRIPTION
## Summary
- Fixed clippy::uninlined_format_args warnings in dns_discovery.rs
- Standardized CI and publish workflows to use `--features full` instead of `--all-features`
- This ensures the CI checks match what the publish workflow will check, preventing future publish failures

## Context
The v1.0.3 release failed because the publish workflow runs clippy with `--all-features` while the CI workflow runs it without any feature flags. This meant DNS-specific code wasn't being checked by clippy in normal CI runs.

## Test plan
- [x] Verified clippy passes with `--features full`
- [x] CI will now catch these issues before attempting to publish