### PR TITLE
feat: allow for transparent host header behaviour

### DIFF
--- a/src/forward.rs
+++ b/src/forward.rs
@@ -11,7 +11,7 @@ use hyper_util::client::legacy::{Client, connect::Connect, connect::HttpConnecto
 use std::convert::Infallible;
 use tracing::{error, trace};
 
-use crate::websocket;
+use crate::{proxy::ProxyPolicy, websocket};
 
 #[cfg(all(feature = "tls", not(feature = "native-tls")))]
 pub(crate) type ProxyClient = Client<HttpsConnector<HttpConnector>, Body>;
@@ -73,6 +73,7 @@ pub(crate) async fn forward_request<C>(
     upstream_uri: Uri,
     req: Request<Body>,
     client: &Client<C, Body>,
+    policy: &ProxyPolicy,
 ) -> Result<Response<Body>, Infallible>
 where
     C: Connect + Clone + Send + Sync + 'static,
@@ -87,7 +88,7 @@ where
     // Check if this is a WebSocket upgrade request
     if websocket::is_websocket_upgrade(req.headers()) {
         trace!("Detected WebSocket upgrade request");
-        match websocket::handle_websocket_with_upstream_uri(req, upstream_uri).await {
+        match websocket::handle_websocket_with_upstream_uri(req, upstream_uri, policy).await {
             Ok(response) => return Ok(response),
             Err(e) => {
                 error!("Failed to handle WebSocket upgrade: {}", e);
@@ -105,9 +106,10 @@ where
             .method(req.method().clone())
             .uri(upstream_uri);
 
-        // Forward headers (except host, which will be set by the client)
+        // Forward headers. When the policy replaces the host, drop the client's
+        // host so the hyper client backfills it from the upstream authority.
         for (key, value) in req.headers() {
-            if key != "host" {
+            if key != "host" || policy.forwards_client_host() {
                 builder = builder.header(key, value);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub use danger::create_dangerous_native_tls_connector;
 pub use danger::create_dangerous_rustls_config;
 #[cfg(feature = "dns")]
 pub use dns_discovery::{DnsDiscovery, DnsDiscoveryConfig, StaticDnsDiscovery};
-pub use proxy::ReverseProxy;
+pub use proxy::{HostBehaviour, ProxyPolicy, ReverseProxy};
 pub use retry::RetryLayer;
 pub use rfc9110::{Rfc9110Config, Rfc9110Layer};
 pub use router_ext::{ProxyRouterExt, TargetResolver, TemplateTarget, proxy_template};

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -17,6 +17,56 @@ pub struct ReverseProxy<C: Connect + Clone + Send + Sync + 'static> {
     path: String,
     target: String,
     client: Client<C, Body>,
+    policy: ProxyPolicy,
+}
+
+/// Behavioural knobs applied to every request a [`ReverseProxy`] forwards.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ProxyPolicy {
+    /// How the upstream `Host` header is derived. See [`HostBehaviour`].
+    pub host_behaviour: HostBehaviour,
+}
+
+impl ProxyPolicy {
+    /// Whether the client's original `Host` header is forwarded upstream rather
+    /// than replaced with the upstream authority
+    pub(crate) fn forwards_client_host(&self) -> bool {
+        matches!(self.host_behaviour, HostBehaviour::Preserve)
+    }
+
+    /// Resolve the single `Host` header value to send upstream, given the
+    /// client's request headers and the upstream authority to fall back to.
+    ///
+    /// Under [`HostBehaviour::Preserve`] this is the client's `Host`, falling
+    /// back to `upstream_authority` when the client sent none (e.g. an HTTP/2
+    /// client whose `:authority` is not surfaced as a `Host` header). Otherwise
+    /// it is always `upstream_authority`.
+    pub(crate) fn forwarded_host(
+        &self,
+        client_headers: &http::HeaderMap,
+        upstream_authority: String,
+    ) -> String {
+        if self.forwards_client_host() {
+            client_headers
+                .get(http::header::HOST)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_owned)
+                .unwrap_or(upstream_authority)
+        } else {
+            upstream_authority
+        }
+    }
+}
+
+/// Controls the value of the `Host` header sent to the upstream server.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum HostBehaviour {
+    /// Forward the client's original `Host` header unchanged.
+    Preserve,
+    /// Replace `Host` with the upstream target's authority (the default, and
+    /// the behaviour of every prior release).
+    #[default]
+    Replace,
 }
 
 pub type StandardReverseProxy = ReverseProxy<ProxyConnector>;
@@ -89,7 +139,15 @@ impl<C: Connect + Clone + Send + Sync + 'static> ReverseProxy<C> {
             path: path.into(),
             target: target.into(),
             client,
+            policy: ProxyPolicy::default(),
         }
+    }
+
+    /// Apply a [`ProxyPolicy`] to this proxy, overriding the default behaviour.
+    #[must_use]
+    pub fn with_policy(mut self, policy: ProxyPolicy) -> Self {
+        self.policy = policy;
+        self
     }
 
     /// Get the base path this proxy is configured to handle
@@ -123,7 +181,7 @@ impl<C: Connect + Clone + Send + Sync + 'static> ReverseProxy<C> {
         let upstream_uri = self.transform_uri(path_q);
 
         // Use shared forwarding logic
-        forward_request(upstream_uri, req, &self.client).await
+        forward_request(upstream_uri, req, &self.client, &self.policy).await
     }
 
     /// Transform an incoming request path+query into the target URI using http::Uri builder
@@ -265,7 +323,49 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::StandardReverseProxy as ReverseProxy;
+    use super::{HostBehaviour, ProxyPolicy, StandardReverseProxy as ReverseProxy};
+
+    fn headers_with_host(host: Option<&str>) -> http::HeaderMap {
+        let mut headers = http::HeaderMap::new();
+        if let Some(host) = host {
+            headers.insert(http::header::HOST, host.parse().unwrap());
+        }
+        headers
+    }
+
+    #[test]
+    fn upstream_host_with_replace_policy_uses_upstream_authority() {
+        let policy = ProxyPolicy::default();
+        let headers = headers_with_host(Some("client.example.com"));
+        assert_eq!(
+            policy.forwarded_host(&headers, "upstream:8080".to_string()),
+            "upstream:8080"
+        );
+    }
+
+    #[test]
+    fn upstream_host_with_preserve_policy_uses_client_host() {
+        let policy = ProxyPolicy {
+            host_behaviour: HostBehaviour::Preserve,
+        };
+        let headers = headers_with_host(Some("client.example.com"));
+        assert_eq!(
+            policy.forwarded_host(&headers, "upstream:8080".to_string()),
+            "client.example.com"
+        );
+    }
+
+    #[test]
+    fn upstream_host_with_preserve_policy_and_no_client_host_falls_back_to_authority() {
+        let policy = ProxyPolicy {
+            host_behaviour: HostBehaviour::Preserve,
+        };
+        let headers = headers_with_host(None);
+        assert_eq!(
+            policy.forwarded_host(&headers, "upstream:8080".to_string()),
+            "upstream:8080"
+        );
+    }
 
     #[test]
     fn transform_uri_with_and_without_trailing_slash() {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -20,7 +20,7 @@ pub struct ReverseProxy<C: Connect + Clone + Send + Sync + 'static> {
     policy: ProxyPolicy,
 }
 
-/// Behavioural knobs applied to every request a [`ReverseProxy`] forwards.
+/// Proxy route and behavioural config to every request a [`ReverseProxy`] forwards.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ProxyPolicy {
     /// How the upstream `Host` header is derived. See [`HostBehaviour`].

--- a/src/router_ext.rs
+++ b/src/router_ext.rs
@@ -28,7 +28,10 @@ use http::uri::Builder as UriBuilder;
 use std::convert::Infallible;
 use tracing::{error, trace};
 
-use crate::forward::{ProxyClient, create_proxy_client, forward_request};
+use crate::{
+    forward::{ProxyClient, create_proxy_client, forward_request},
+    proxy::ProxyPolicy,
+};
 
 /// A trait for resolving the target URL for a proxy request.
 ///
@@ -185,14 +188,37 @@ pub trait ProxyRouterExt<S> {
     ///     // Dynamic proxy with path substitution
     ///     .proxy_route("/users/{id}", proxy_template("https://users.example.com/{id}"));
     /// ```
-    fn proxy_route<T: TargetResolver>(self, path: &str, target: T) -> Self;
+    fn proxy_route<T: TargetResolver>(self, path: &str, target: T) -> Self
+    where
+        Self: Sized,
+    {
+        self.proxy_route_with_policy(path, target, ProxyPolicy::default())
+    }
+
+    /// Add a proxy route with an explicit [`ProxyPolicy`].
+    ///
+    /// Identical to [`proxy_route`](Self::proxy_route) but lets the caller
+    /// override forwarding behaviour (e.g. preserving the client's `Host`
+    /// header). [`proxy_route`](Self::proxy_route) is the [`ProxyPolicy::default`]
+    /// case of this method.
+    fn proxy_route_with_policy<T: TargetResolver>(
+        self,
+        path: &str,
+        target: T,
+        policy: ProxyPolicy,
+    ) -> Self;
 }
 
 impl<S> ProxyRouterExt<S> for Router<S>
 where
     S: Clone + Send + Sync + 'static,
 {
-    fn proxy_route<T: TargetResolver>(self, path: &str, target: T) -> Self {
+    fn proxy_route_with_policy<T: TargetResolver>(
+        self,
+        path: &str,
+        target: T,
+        policy: ProxyPolicy,
+    ) -> Self {
         let client = create_proxy_client();
 
         self.route(
@@ -201,7 +227,8 @@ where
                 move |Path(params): Path<Vec<(String, String)>>, req: Request<Body>| {
                     let target = target.clone();
                     let client = client.clone();
-                    async move { proxy_request(target, params, req, client).await }
+                    let policy = policy.clone();
+                    async move { proxy_request(target, params, req, client, &policy).await }
                 },
             ),
         )
@@ -213,6 +240,7 @@ async fn proxy_request<T: TargetResolver>(
     params: Vec<(String, String)>,
     req: Request<Body>,
     client: ProxyClient,
+    policy: &ProxyPolicy,
 ) -> Result<Response<Body>, Infallible> {
     let target_url = target.resolve(&req, &params);
     trace!("Proxying request to resolved target: {}", target_url);
@@ -233,7 +261,7 @@ async fn proxy_request<T: TargetResolver>(
     let upstream_uri = build_upstream_uri(&target_uri, req.uri());
 
     // Use shared forwarding logic
-    forward_request(upstream_uri, req, &client).await
+    forward_request(upstream_uri, req, &client, policy).await
 }
 
 /// Build the upstream URI from the target and original request.

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -10,10 +10,15 @@ use tokio::sync::mpsc;
 use tokio::time::{Duration, timeout};
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream, connect_async,
-    tungstenite::{Error, Message, handshake::derive_accept_key},
+    tungstenite::{
+        Error, Message,
+        handshake::{self, derive_accept_key},
+    },
 };
 use tracing::{error, trace};
 use url::{Host, Url};
+
+use crate::proxy::ProxyPolicy;
 
 /// Check if a request is a WebSocket upgrade request by examining the headers.
 ///
@@ -103,6 +108,7 @@ fn compute_host_header(url: &str) -> (String, u16) {
 pub(crate) async fn handle_websocket_with_upstream_uri(
     req: Request<Body>,
     upstream_http_uri: Uri,
+    policy: &ProxyPolicy,
 ) -> Result<Response<Body>, Box<dyn std::error::Error + Send + Sync>> {
     trace!("Handling WebSocket upgrade request");
 
@@ -141,17 +147,19 @@ pub(crate) async fn handle_websocket_with_upstream_uri(
     let url = Url::parse(&upstream_url)?;
     let (host_header, _port) = compute_host_header_from_url(&url);
 
-    // Forward all headers except host and sec-websocket-extensions to upstream.
-    // Extensions are stripped because the proxy performs frame-level forwarding and
-    // cannot transparently handle negotiated extensions (e.g. permessage-deflate).
-    let mut request = tokio_tungstenite::tungstenite::handshake::client::Request::builder()
-        .uri(upstream_url)
-        .header("host", host_header);
+    let upstream_host = policy.forwarded_host(req.headers(), host_header);
 
+    let mut request = handshake::client::Request::builder()
+        .uri(upstream_url)
+        .header("host", upstream_host);
+
+    // sec-websocket-extensions is stripped because the proxy forwards frames
+    // verbatim and cannot honour negotiated extensions (e.g. permessage-deflate).
     for (key, value) in req.headers() {
-        if key != "host" && key != "sec-websocket-extensions" {
-            request = request.header(key.as_str(), value);
+        if key == "host" || key == "sec-websocket-extensions" {
+            continue;
         }
+        request = request.header(key.as_str(), value);
     }
 
     // Build the request

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,8 +1,8 @@
 use axum::{Router, body::Body, http::Request, response::Json, routing::get};
-use axum_reverse_proxy::ReverseProxy;
+use axum_reverse_proxy::{HostBehaviour, ProxyPolicy, ReverseProxy};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::{Value, json};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{net::TcpListener, sync::Notify};
 
 async fn echo_headers(req: Request<Body>) -> Json<Value> {
@@ -207,4 +207,74 @@ async fn test_proxy_special_headers() {
         }
         Err(_) => panic!("Test timed out after 10 seconds"),
     }
+}
+
+/// Spin up an echo-headers upstream and a proxy configured with `policy`,
+/// returning (upstream_addr, proxy_addr). Both servers are spawned as
+/// background tasks that live for the duration of the test process.
+async fn setup_host_policy_proxy(policy: ProxyPolicy) -> (SocketAddr, SocketAddr) {
+    let app = Router::new().route("/headers", get(echo_headers));
+    let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream_addr = upstream_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(upstream_listener, app).await.unwrap();
+    });
+
+    let proxy = ReverseProxy::new("/", &format!("http://{upstream_addr}")).with_policy(policy);
+    let proxy_app: Router = proxy.into();
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(proxy_listener, proxy_app).await.unwrap();
+    });
+
+    (upstream_addr, proxy_addr)
+}
+
+/// Send a request through the proxy with an explicit `Host` header and return
+/// the `host` value the upstream echoed back.
+async fn upstream_host_seen(proxy_addr: SocketAddr, client_host: &str) -> String {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap();
+
+    let body: Value = client
+        .get(format!("http://{proxy_addr}/headers"))
+        .header(reqwest::header::HOST, client_host)
+        .send()
+        .await
+        .expect("request to proxy failed")
+        .json()
+        .await
+        .expect("response was not json");
+
+    body["headers"]["host"]
+        .as_str()
+        .expect("upstream did not echo a host header")
+        .to_string()
+}
+
+#[tokio::test]
+async fn host_header_with_default_policy_replaces_host_with_upstream_authority() {
+    let (upstream_addr, proxy_addr) = setup_host_policy_proxy(ProxyPolicy::default()).await;
+
+    let seen = upstream_host_seen(proxy_addr, "client.example.com").await;
+
+    // Default (Replace) behaviour: upstream sees its own authority, not the
+    // client-supplied host.
+    assert_eq!(seen, upstream_addr.to_string());
+}
+
+#[tokio::test]
+async fn host_header_with_preserve_policy_forwards_client_host() {
+    let policy = ProxyPolicy {
+        host_behaviour: HostBehaviour::Preserve,
+    };
+    let (_upstream_addr, proxy_addr) = setup_host_policy_proxy(policy).await;
+
+    let seen = upstream_host_seen(proxy_addr, "client.example.com").await;
+
+    // Preserve behaviour: the client's original host flows through unchanged.
+    assert_eq!(seen, "client.example.com");
 }

--- a/tests/router_ext.rs
+++ b/tests/router_ext.rs
@@ -6,7 +6,9 @@ use axum::{
     http::{Request, StatusCode},
     routing::get,
 };
-use axum_reverse_proxy::{ProxyRouterExt, TargetResolver, proxy_template};
+use axum_reverse_proxy::{
+    HostBehaviour, ProxyPolicy, ProxyRouterExt, TargetResolver, proxy_template,
+};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 use tower::ServiceExt;
@@ -23,6 +25,13 @@ async fn create_backend() -> (SocketAddr, tokio::task::JoinHandle<()>) {
         }))
         .route("/api/{*rest}", get(|axum::extract::Path(rest): axum::extract::Path<String>| async move {
             format!("api:{}", rest)
+        }))
+        .route("/echo-host", get(|req: Request<Body>| async move {
+            req.headers()
+                .get("host")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("<none>")
+                .to_string()
         }));
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -253,4 +262,57 @@ async fn test_multiple_proxy_routes() {
         .await
         .unwrap();
     assert_eq!(&body2[..], b"video:vid001:1080p");
+}
+
+#[tokio::test]
+async fn proxy_route_with_preserve_policy_forwards_client_host() {
+    let (backend_addr, _handle) = create_backend().await;
+    let target = format!("http://{backend_addr}/echo-host");
+
+    let app: Router = Router::new().proxy_route_with_policy(
+        "/echo-host",
+        target,
+        ProxyPolicy {
+            host_behaviour: HostBehaviour::Preserve,
+        },
+    );
+
+    let req = Request::builder()
+        .uri("/echo-host")
+        .header("host", "client.example.com")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    // Preserve behaviour: the client's host reaches the backend unchanged.
+    assert_eq!(&body[..], b"client.example.com");
+}
+
+#[tokio::test]
+async fn proxy_route_with_default_policy_replaces_host_with_upstream_authority() {
+    let (backend_addr, _handle) = create_backend().await;
+    let target = format!("http://{backend_addr}/echo-host");
+
+    // The plain `proxy_route` defaults to Replace; assert the backend sees its
+    // own authority rather than the client-supplied host.
+    let app: Router = Router::new().proxy_route("/echo-host", target);
+
+    let req = Request::builder()
+        .uri("/echo-host")
+        .header("host", "client.example.com")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], backend_addr.to_string().as_bytes());
 }

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -390,3 +390,114 @@ async fn test_websocket_ping_pong() {
         }
     }
 }
+
+/// Upstream WebSocket handler that reports every `host` header value it
+/// received on the upgrade handshake over a channel, then echoes frames.
+async fn ws_host_capture_handler(
+    ws: WebSocketUpgrade,
+    State(tx): State<tokio::sync::mpsc::Sender<Vec<String>>>,
+    headers: axum::http::HeaderMap,
+) -> impl IntoResponse {
+    let hosts: Vec<String> = headers
+        .get_all("host")
+        .iter()
+        .map(|v| v.to_str().unwrap_or_default().to_string())
+        .collect();
+    let _ = tx.send(hosts).await;
+    ws.on_upgrade(handle_socket)
+}
+
+/// Stand up a host-capturing upstream and a proxy with `policy`, returning
+/// (upstream_addr, proxy_addr, host receiver).
+async fn setup_ws_host_policy_proxy(
+    policy: axum_reverse_proxy::ProxyPolicy,
+) -> (
+    SocketAddr,
+    SocketAddr,
+    tokio::sync::mpsc::Receiver<Vec<String>>,
+) {
+    let (tx, rx) = tokio::sync::mpsc::channel::<Vec<String>>(1);
+    let app = Router::new()
+        .route("/ws", get(ws_host_capture_handler))
+        .with_state(tx);
+    let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream_addr = upstream_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(upstream_listener, app).await.unwrap();
+    });
+
+    let proxy = ReverseProxy::new("/", &format!("http://{upstream_addr}")).with_policy(policy);
+    let proxy_app: Router = proxy.into();
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(proxy_listener, proxy_app).await.unwrap();
+    });
+
+    (upstream_addr, proxy_addr, rx)
+}
+
+/// Connect to the proxy with an explicit client `Host` header and return the
+/// host header values the upstream saw on the handshake.
+async fn upstream_ws_hosts_seen(
+    proxy_addr: SocketAddr,
+    client_host: &str,
+    rx: &mut tokio::sync::mpsc::Receiver<Vec<String>>,
+) -> Vec<String> {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+    let url = format!("ws://127.0.0.1:{}/ws", proxy_addr.port());
+    let mut request = url.into_client_request().unwrap();
+    request
+        .headers_mut()
+        .insert("host", client_host.parse().unwrap());
+
+    let (_ws, _) = tokio_tungstenite::connect_async(request)
+        .await
+        .expect("ws connect via proxy");
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("no host captured before timeout")
+        .expect("host channel closed")
+}
+
+#[tokio::test]
+async fn websocket_host_header_with_default_policy_replaces_host_with_upstream_authority() {
+    use axum_reverse_proxy::ProxyPolicy;
+
+    let (upstream_addr, proxy_addr, mut rx) =
+        setup_ws_host_policy_proxy(ProxyPolicy::default()).await;
+
+    let hosts = upstream_ws_hosts_seen(proxy_addr, "client.example.com", &mut rx).await;
+
+    // Exactly one Host header (regression guard against duplicate emission)...
+    assert_eq!(
+        hosts.len(),
+        1,
+        "expected exactly one host header, got {hosts:?}"
+    );
+    // ...set to the upstream authority under the default Replace behaviour.
+    assert_eq!(hosts[0], upstream_addr.to_string());
+}
+
+#[tokio::test]
+async fn websocket_host_header_with_preserve_policy_forwards_single_client_host() {
+    use axum_reverse_proxy::{HostBehaviour, ProxyPolicy};
+
+    let policy = ProxyPolicy {
+        host_behaviour: HostBehaviour::Preserve,
+    };
+    let (_upstream_addr, proxy_addr, mut rx) = setup_ws_host_policy_proxy(policy).await;
+
+    let hosts = upstream_ws_hosts_seen(proxy_addr, "client.example.com", &mut rx).await;
+
+    // Still exactly one Host header — Preserve must not also append the
+    // upstream authority, which would emit a duplicate.
+    assert_eq!(
+        hosts.len(),
+        1,
+        "expected exactly one host header, got {hosts:?}"
+    );
+    assert_eq!(hosts[0], "client.example.com");
+}


### PR DESCRIPTION
Adds a proxy policy object that allows a configurable proxy policy behaviour for hosts on either endpoints or proxy instances. This is common for proxies to support in general as many production servers/web services require an allow list for hosts and rewriting to a localhost instance (like in a sidecar) means that with the existing framework we're handing "localhost" which isn't often a trusted hostname.

This allows for transparent host header behaviours but defaults anything existing to "replace" which was the previous only behaviour.

Another thing I was thinking of adding is `X-Forwarded-<>` and `Forwarded` header support since I already had to include it in the proxy I use this for at work and it's not a big change (Though respecting it would be)